### PR TITLE
.travis.yml: Fail if coverage less than 100

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 
 script:
   - coala --non-interactive -V
-  - python -m pytest --cov tests/
+  - python -m pytest --cov tests --cov-fail-under=100
   - docker build -t "corobo" .
   - docker images
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - python -m pytest --cov tests --cov-fail-under=100
   - docker build -t "corobo" .
   - docker images
+  - codecov
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # corobo
 
+[![Travis branch](https://img.shields.io/travis/coala/corobo/master.svg)](https://travis-ci.org/coala/corobo)
+[![Codecov branch](https://img.shields.io/codecov/c/github/coala/corobo/master.svg)](https://codecov.io/gh/coala/corobo)
+
 ## Setup
 
 1. Install the dependencies

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ pytest
 coverage
 pytest-cov
 requests_mock
+codecov


### PR DESCRIPTION
Closes https://github.com/coala/corobo/issues/80

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
