### PR TITLE
.travis.yml: Calculate coverage of plugins and not tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 
 script:
   - coala --non-interactive -V
-  - python -m pytest --cov tests --cov-fail-under=100
+  - python -m pytest tests/ --cov plugins/ --cov-fail-under=100
   - docker build -t "corobo" .
   - docker images
   - codecov


### PR DESCRIPTION
Fixes https://github.com/coala/corobo/issues/85

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
