### PR TITLE
utils: Add install requirements command

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -6,12 +6,15 @@ import git
 from errbot import BotPlugin, botcmd
 
 
+run = lambda x: subprocess.Popen(x.split(), stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+
 class Utils(BotPlugin):
     """
     Some random utilities
     """
 
-    @botcmd
+    @botcmd(admin_only=True)
     def sync(self, msg, arg):
         """Sync the repository from github."""  # Ignore QuotesBear
         repo = git.Repo(os.environ.get('COBOT_ROOT'))
@@ -27,3 +30,12 @@ class Utils(BotPlugin):
         repo = git.Repo(os.environ.get('COBOT_ROOT'))
         head = repo.commit('HEAD')
         yield '`{}`: {}'.format(head.hexsha, head.message)
+
+    @botcmd(admin_only=True)
+    def install_requirements(self, msg, arg):
+        """Installs requirements"""  # Ignore QuotesBear
+        os.chdir(os.environ.get('COBOT_ROOT'))
+        ran = run('pip install -r requirements.txt')
+        yield 'installing requirements...'
+        yield ran.stdout.read().decode('utf-8')
+        yield ran.stderr.read().decode('utf-8')


### PR DESCRIPTION
- Install requirements by running pip install in subprocess.
- Make `sync` admin_only command.

Closes https://github.com/coala/corobo/issues/151

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
