### PR TITLE
labhub: Fix typo then -> than

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -272,7 +272,7 @@ class LabHub(BotPlugin):
 
         eligility_conditions = [
             '- A newcomer cannot be assigned to an issue with a difficulty '
-            'level higher then newcomer or low difficulty.',
+            'level higher than newcomer or low difficulty.',
         ]
 
         try:


### PR DESCRIPTION
Eligibility message changed from 'then newcomers' to 'than newcomers'

Fixes https://github.com/coala/corobo/issues/157

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
