### PR TITLE
Enhances issue assign failure message

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -269,6 +269,9 @@ class LabHub(BotPlugin):
             return True
 
         eligility_conditions = [
+            '- You must be a member of coala org to be assigned an issue '
+            'If you are not a member yet, just type Hello World and '
+            'corobo will invite you.',
             '- A newcomer cannot be assigned to an issue with a difficulty '
             'level higher than newcomer or low difficulty.',
         ]


### PR DESCRIPTION
When issue assignment fails, suggests that user may not be part of coala
org yet.

Closes https://github.com/coala/corobo/issues/181

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
