### PR TITLE
labhub: Maintain a list of invited users

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -78,6 +78,8 @@ class LabHub(BotPlugin):
         else:
             self.REPOS.update(self.gl_repos)
 
+        self.invited_users = set()
+
     @property
     def TEAMS(self):
         return self._teams
@@ -121,11 +123,13 @@ class LabHub(BotPlugin):
         """Invite the user whose message includes the holy 'hello world'"""
         if re.search(r'hello\s*,?\s*world', msg.body, flags=re.IGNORECASE):
             user = msg.frm.nick
-            if not self.TEAMS[self.GH_ORG_NAME + ' newcomers'].is_member(user):
+            if (not self.TEAMS[self.GH_ORG_NAME + ' newcomers'].is_member(user)
+                    and user not in self.invited_users):
                 # send the invite
                 self.send(msg.frm,
                           self.INVITE_SUCCESS['newcomers'].format(user))
                 self.TEAMS[self.GH_ORG_NAME + ' newcomers'].invite(user)
+                self.invited_users.add(user)
 
     @re_botcmd(pattern=r'(?:new|file) issue ([\w-]+?)(?: |\n)(.+?)(?:$|\n((?:.|\n)*))',  # Ignore LineLengthBear, PyCodeStyleBear
                flags=re.IGNORECASE)

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import queue
 import unittest
 from unittest.mock import Mock, MagicMock, create_autospec, PropertyMock
 
@@ -67,7 +68,10 @@ class TestLabHub(unittest.TestCase):
         labhub.TEAMS = teams
         self.mock_team.is_member.return_value = False
         testbot.assertCommand('hello, world', 'newcomer')
-        testbot.assertCommand('helloworld', 'newcomer')
+        # Since the user won't be invited again, it'll timeout waiting for a
+        # response.
+        with self.assertRaises(queue.Empty):
+            testbot.assertCommand('helloworld', 'newcomer')
         self.mock_team.invite.assert_called_with(None)
 
     def test_create_issue_cmd(self):


### PR DESCRIPTION
Closes https://github.com/coala/corobo/issues/225

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
