### PR TITLE
labhub.py: Add eligibility condition

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -309,6 +309,7 @@ class LabHub(BotPlugin):
             'corobo will invite you.'.format(self.GH_ORG_NAME),
             '- A newcomer cannot be assigned to an issue with a difficulty '
             'level higher than newcomer or low difficulty.',
+            '- A newcomer cannot be assigned to unlabelled issues.'
         ]
 
         try:


### PR DESCRIPTION
Add eligibility condition where in a newcomer 
can not be assigned to an un-labelled issue

Closes https://github.com/coala/corobo/issues/232

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
