### PR TITLE
labhub.py: Add reassign message

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -337,6 +337,8 @@ class LabHub(BotPlugin):
                 else:
                     yield 'You are not eligible to be assigned to this issue.'
                     yield '\n'.join(eligility_conditions)
+            elif user in iss.assignees:
+                yield ('The issue is already assigned to you.')
             else:
                 yield ('The issue is already assigned to someone. Please '
                        'check if the assignee is still working on the issue, '

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -203,6 +203,11 @@ class TestLabHub(unittest.TestCase):
         testbot.assertCommand(cmd.format('coala', 'a', '23'),
                               'already assigned to someone')
 
+        # has assignee same as user
+        mock_issue.assignees = (None, )
+        testbot.assertCommand(cmd.format('coala', 'a', '23'),
+                              'already assigned to you')
+
         # non-existent repository
         testbot.assertCommand(cmd.format('coala', 'c', '23'),
                               'Repository doesn\'t exist.')


### PR DESCRIPTION
This will generate a message that issue is already assigned to you, if both user and assignee are same.

Closes https://github.com/coala/corobo/issues/324