### PR TITLE
labhub.py: Add comma in eligility_conditions

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -320,7 +320,7 @@ class LabHub(BotPlugin):
             'corobo will invite you.'.format(self.GH_ORG_NAME),
             '- A newcomer cannot be assigned to an issue with a difficulty '
             'level higher than newcomer or low difficulty.',
-            '- A newcomer cannot be assigned to unlabelled issues.'
+            '- A newcomer cannot be assigned to unlabelled issues.',
             '- initiatives/gci labelled issue assignments are blocked.'
         ]
 


### PR DESCRIPTION
This change makes the GCI related condition of corobo message to appear
in a new line.

Closes https://github.com/coala/corobo/issues/310

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
