### PR TITLE
[WIP] labhub.py: Prevent duplicate issue title

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -162,6 +162,12 @@ class LabHub(BotPlugin):
 
         if repo_name in self.REPOS:
             repo = self.REPOS[repo_name]
+            # TODO: Return the url to the issue with duplicate issue title
+            # in the return string.
+            for issue in list(repo.search_issues()):
+                if iss_title == issue.title:
+                    return ('Can\'t create an issue with the given title ')
+
             iss = repo.create_issue(iss_title, iss_description + extra_msg)
             return 'Here you go: {}'.format(iss.url)
         else:


### PR DESCRIPTION
Before opening a new issue, check for duplicate
issue title in the repo and prevent from opening
if there's any.

Taking a shot at https://github.com/coala/corobo/issues/291. Am I on the right track?

cc: @meetmangukiya @jayvdb 


# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
