### PR TITLE
filters.py: Add note help diverted to private

### DIFF
--- a/utils/filters.py
+++ b/utils/filters.py
@@ -27,3 +27,12 @@ class Filters(BotPlugin):
         if msg.frm.nick in self.bot_config.IGNORE_USERNAMES:
             return None, None, None
         return msg, cmd, args
+
+    @cmdfilter
+    def filter_private_diverts(self, msg, cmd, args, dry_run):
+        """
+        Leave a message that response is diverted as private message.
+        """
+        if cmd in self.bot_config.DIVERT_TO_PRIVATE:
+            self.send(msg.frm, '@{}, help message is diverted into private, check DM with @co-robo')
+        return msg, cmd, args


### PR DESCRIPTION
This leaves a message that 'help' command
is diverted to private message

Closes https://github.com/coala/corobo/issues/145

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
