### PR TITLE
labhub.py: Fix invite command regex bug

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -96,7 +96,7 @@ class LabHub(BotPlugin):
         self._teams = new
 
     # Ignore LineLengthBear, PycodestyleBear
-    @re_botcmd(pattern=r'(?:(?:invite)|(?:inv))\s+(?:(?:@?([\w-]+)(?:\s*(?:to)\s+(\w+))?)|(me))',
+    @re_botcmd(pattern=r'^(?:(?:invite)|(?:inv))\s+(?:(?:@?([\w-]+)(?:\s*(?:to)\s+(\w+))?)|(me))$',
                re_cmd_name_help='invite [to team]')
     def invite_cmd(self, msg, match):
         """

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -294,3 +294,8 @@ class TestLabHub(unittest.TestCase):
                               'We\'ve just sent you an invite')
         with self.assertRaises(queue.Empty):
             testbot.pop_message()
+
+        testbot.assertCommand('!hey there invite me',
+                              'Command \"hey\" / \"hey there\" not found.')
+        with self.assertRaises(queue.Empty):
+             testbot.pop_message()


### PR DESCRIPTION
This prepends ^ in the invite command
regex to make sure it is not triggered
from anywhere in the conversation

Fixes https://github.com/coala/corobo/issues/215

Also Fixes https://github.com/coala/corobo/issues/323

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
