### PR TITLE
config.py: Add special case for Text backend

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,6 +22,9 @@ if not os.environ.get('COBOT_PREFIX'):
     BOT_ALT_PREFIXES = ('cobot ', )
 
 BOT_ADMINS = os.environ.get('BOT_ADMINS', '').split() or ('*@localhost', )
+# Text is a special case
+if BACKEND == 'Text':
+    BOT_ADMINS = ('@localhost', )
 
 BOT_IDENTITY = {
     'token': os.environ.get('COBOT_TOKEN')


### PR DESCRIPTION
The Text backend needs the bot admin to start with `@`.

Fixes https://github.com/coala/corobo/issues/393

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
