### PR TITLE
config.py: Limit render test in test room

### DIFF
--- a/config.py
+++ b/config.py
@@ -55,4 +55,7 @@ ROOMS_TO_JOIN = (
 
 CHATROOM_PRESENCE = os.environ.get('ROOMS', '').split() or ROOMS_TO_JOIN
 
+ACCESS_CONTROLS = {'render test': {
+    'allowrooms': ('coala/cobot-test', 'coala/corobo',)}, }
+
 AUTOINSTALL_DEPS = True


### PR DESCRIPTION
Add ACCESS_CONTROLS for render test command

Closes https://github.com/coala/corobo/issues/359

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
