### PR TITLE
explain.py: Recognize beginning and end of string

### DIFF
--- a/plugins/explain.py
+++ b/plugins/explain.py
@@ -90,7 +90,7 @@ class Explain(BotPlugin):
         '\n- '.join(MSGS.keys())
     )
 
-    @re_botcmd(pattern=r'explain\s+(\w+)(?:\s+to\s+@?([\w-]+))?',
+    @re_botcmd(pattern=r'^explain\s+(\w+)(?:\s+to\s+@?([\w-]+))?$',
                re_cmd_name_help='explain <term>',
                flags=re.IGNORECASE)
     def explain(self, msg, match):

--- a/tests/explain_test.py
+++ b/tests/explain_test.py
@@ -19,3 +19,5 @@ def test_explain(testbot):
                           text.convert(Explain.ERROR_MSG))
     testbot.assertCommand("!explain review to @meet",
                           '@meet')
+    testbot.assertCommand("!please explain review",
+                          "Command \"please\" / \"please explain\" not found.")


### PR DESCRIPTION
Add ^ and $ to the regex so the command is not triggered
from anywhere in the capture string

Closes https://github.com/coala/corobo/issues/364

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
