### PR TITLE
Revert "LabHub: Block gci issue assignments"

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -299,15 +299,6 @@ class LabHub(BotPlugin):
                 elif self.GH3_ORG.is_member(user):
                     return True
 
-            @register_check
-            def block_gci_issue_assignment(user, iss):
-                """
-                False if the issue is labelled as 'initiatives/gci', else True.
-                """
-                if 'initiatives/gci' in iss.labels:
-                    return False
-                return True
-
         def eligible(user, iss):
             for chk in checks:
                 if not chk(user, iss):
@@ -320,8 +311,7 @@ class LabHub(BotPlugin):
             'corobo will invite you.'.format(self.GH_ORG_NAME),
             '- A newcomer cannot be assigned to an issue with a difficulty '
             'level higher than newcomer or low difficulty.',
-            '- A newcomer cannot be assigned to unlabelled issues.',
-            '- initiatives/gci labelled issue assignments are blocked.'
+            '- A newcomer cannot be assigned to unlabelled issues.'
         ]
 
         try:

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -166,12 +166,6 @@ class TestLabHub(unittest.TestCase):
         testbot.assertCommand(cmd.format('coala', 'a', '23'),
                               'You\'ve been assigned to the issue')
 
-        # no assignee, newcomer, difficulty/low, intiatives/gci
-        mock_issue.labels = ('difficulty/low', 'initiatives/gci')
-        testbot.assertCommand(cmd.format('coala', 'a', '23'),
-                              'not eligible to be assigned to this issue')
-        testbot.pop_message()
-
         # no assignee, newcomer, no labels
         self.mock_team.is_member.return_value = True
         mock_issue.labels = tuple()


### PR DESCRIPTION
This reverts commit 2a505f2e5dc6c02c39007533eb9c6268cf5ccdf5.
