### PR TITLE
labhub.py: Fix spelling mistake

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -149,7 +149,7 @@ class LabHub(BotPlugin):
     @re_botcmd(pattern=r'(?:new|file) issue ([\w-]+?)(?: |\n)(.+?)(?:$|\n((?:.|\n)*))',  # Ignore LineLengthBear, PyCodeStyleBear
                re_cmd_name_help='new issue repo-name title\n[description]',
                flags=re.IGNORECASE)
-    def create_issut_cmd(self, msg, match):
+    def create_issue_cmd(self, msg, match):
         """Create issues on GitHub and GitLab repositories."""  # Ignore QuotesBear, LineLengthBear, PyCodeStyleBear
         repo_name = match.group(1)
         iss_title = match.group(2)


### PR DESCRIPTION
This changes the spelling of `create_issut_cmd` to `create_issue_cmd`.

Closes https://github.com/coala/corobo/issues/362

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
