### PR TITLE
labhub.py: Allow periods in repository names

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -146,7 +146,7 @@ class LabHub(BotPlugin):
                 self.TEAMS[self.GH_ORG_NAME + ' newcomers'].invite(user)
                 self.invited_users.add(user)
 
-    @re_botcmd(pattern=r'(?:new|file) issue ([\w-]+?)(?: |\n)(.+?)(?:$|\n((?:.|\n)*))',  # Ignore LineLengthBear, PyCodeStyleBear
+    @re_botcmd(pattern=r'(?:new|file) issue ([\w\-\.]+?)(?: |\n)(.+?)(?:$|\n((?:.|\n)*))',  # Ignore LineLengthBear, PyCodeStyleBear
                re_cmd_name_help='new issue repo-name title\n[description]',
                flags=re.IGNORECASE)
     def create_issue_cmd(self, msg, match):

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -88,13 +88,21 @@ class TestLabHub(unittest.TestCase):
         plugins.labhub.GitLabPrivateToken.assert_called_with(None)
 
 
-        labhub.REPOS = {'repository': self.mock_repo}
+        labhub.REPOS = {'repository': self.mock_repo,
+                        'repository.github.io': self.mock_repo}
 
         testbot.assertCommand('!new issue repository this is the title\nbo\ndy',
                               'Here you go')
 
         labhub.REPOS['repository'].create_issue.assert_called_once_with(
             'this is the title', 'bo\ndy\nOpened by @None at [text]()'
+        )
+
+        testbot.assertCommand('!new issue repository.github.io another title\nand body',
+                              'Here you go')
+
+        labhub.REPOS['repository.github.io'].create_issue.assert_called_with(
+            'another title', 'and body\nOpened by @None at [text]()'
         )
 
         testbot.assertCommand('!new issue coala title', 'repository that does not exist')


### PR DESCRIPTION
This allows repository names to contain periods when creating
issues, allowing for GitHub pages repos to be used.

Fixes https://github.com/coala/corobo/issues/252

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
