### PR TITLE
labhub.py: Change invite alias

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -96,7 +96,7 @@ class LabHub(BotPlugin):
         self._teams = new
 
     # Ignore LineLengthBear, PycodestyleBear
-    @re_botcmd(pattern=r'^(?:(?:invite)|(?:inv))\s+(?:(?:@?([\w-]+)(?:\s*(?:to)\s+(\w+))?)|(me))$',
+    @re_botcmd(pattern=r'^(?:(?:welcome)|(?:inv)|(?:invite))\s+(?:(?:@?([\w-]+)(?:\s*(?:to)\s+(\w+))?)|(me))$',
                re_cmd_name_help='invite [to team]')
     def invite_cmd(self, msg, match):
         """


### PR DESCRIPTION
labhub.py: Changed invite alias 

Changed invite alias from 'invite' to 'welcome'.

Closes https://github.com/coala/corobo/issues/166

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
