### PR TITLE
utils/utils.py: Use bot configuration

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -17,7 +17,7 @@ class Utils(BotPlugin):
     @botcmd(admin_only=True)
     def sync(self, msg, arg):
         """Sync the repository from github."""  # Ignore QuotesBear
-        repo = git.Repo(os.environ.get('COBOT_ROOT'))
+        repo = git.Repo(self.bot_config.COBOT_ROOT)
         try:
             repo.remote('origin').pull('--rebase')
             yield 'Sync\'d successfully! :tada:'
@@ -27,14 +27,14 @@ class Utils(BotPlugin):
     @botcmd
     def get_head(self, msg, arg):
         """Yields the head commit."""  # Ignore QuotesBear
-        repo = git.Repo(os.environ.get('COBOT_ROOT'))
+        repo = git.Repo(self.bot_config.COBOT_ROOT)
         head = repo.commit('HEAD')
         yield '`{}`: {}'.format(head.hexsha, head.message)
 
     @botcmd(admin_only=True)
     def install_requirements(self, msg, arg):
         """Installs requirements"""  # Ignore QuotesBear
-        os.chdir(os.environ.get('COBOT_ROOT'))
+        os.chdir(self.bot_config.COBOT_ROOT)
         ran = run('pip install -r requirements.txt')
         yield 'installing requirements...'
         yield ran.stdout.read().decode('utf-8')


### PR DESCRIPTION
utils/utils.py: Use bot configuration

Use COBOT_ROOT variable set in config.py
instead of accessing enviroment.

Fixes https://github.com/coala/corobo/issues/384

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
