### PR TITLE
labhub.py: Ping PR author when marking WIP

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -214,6 +214,12 @@ class LabHub(BotPlugin):
             return 'Repository doesn\'t exist.'
         else:
             current_labels = list(mr.labels)
+            data = mr.data
+            login = None
+            if 'user' in data:
+                login = data['user']['login']
+            elif 'author' in data:
+                login = data['author']['username']
             if state == 'wip':
                 pending_labels = ['process/pending_review',
                                   'process/pending review']
@@ -222,12 +228,19 @@ class LabHub(BotPlugin):
                     current_labels.remove(label)
                 current_labels.append('process/wip')
                 mr.labels = current_labels
+
+                ping = ''
+                if login is not None:
+                    ping = ('\n@{user_login}, please check your pull '
+                            'request.'.format(user_login=login))
+
                 return ('The pull request {mr_link} is marked *work in progress'
                         '*. Use `{bot_prefix} mark pending` or push to your '
                         'branch if feedback from the community is needed '
-                        'again.'.format(
+                        'again.{ping}'.format(
                             mr_link=mr.url,
-                            bot_prefix=self.bot_config.BOT_PREFIX)
+                            bot_prefix=self.bot_config.BOT_PREFIX,
+                            ping=ping)
                         )
             else:
                 wip_labels = ['process/wip']


### PR DESCRIPTION
This will ping the author of a PR when it is marked as WIP through the
`corobo mark wip <issue>` command.

Closes https://github.com/coala/corobo/issues/333

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
