### PR TITLE
labhub.py: Add "mark pending review" alias

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -196,7 +196,7 @@ class LabHub(BotPlugin):
             else:
                 return 'You are not an assignee on the issue.'
 
-    @re_botcmd(pattern=r'mark\s+(wip|pending)\s+https://(github|gitlab)\.com/([^/]+)/([^/]+)/(pull|merge_requests)/(\d+)',  # Ignore LineLengthBear, PyCodeStyleBear
+    @re_botcmd(pattern=r'mark\s+(wip|pending(?:(?:-|\s+)review)?\b)\s+https://(github|gitlab)\.com/([^/]+)/([^/]+)/(pull|merge_requests)/(\d+)',  # Ignore LineLengthBear, PyCodeStyleBear
                re_cmd_name_help='mark (wip|pending) <complete-PR-URL>',
                flags=re.IGNORECASE)
     def mark_cmd(self, msg, match):

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -261,6 +261,10 @@ class TestLabHub(unittest.TestCase):
         mock_gitlab_mr.labels = ['process/wip']
         testbot.assertCommand(cmd_github.format('pending', 'coala', 'a', '23'),
                               'marked pending review')
+        testbot.assertCommand(cmd_github.format('pending-review', 'coala', 'a', '23'),
+                              'marked pending review')
+        testbot.assertCommand(cmd_github.format('pending review', 'coala', 'a', '23'),
+                              'marked pending review')
 
     def test_alive(self):
         labhub, testbot = plugin_testbot(plugins.labhub.LabHub, logging.ERROR)


### PR DESCRIPTION
labhub.py: Add "mark pending review" alias

Add "mark pending review" and
"mark pending-review" aliases.

Fixes https://github.com/coala/corobo/issues/335

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
