### PR TITLE
WIP: labhub: Allow missing username and msg link

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -154,11 +154,22 @@ class LabHub(BotPlugin):
         repo_name = match.group(1)
         iss_title = match.group(2)
         iss_description = match.group(3) if match.group(3) is not None else ''
-        extra_msg = '\nOpened by @{username} at [{backend}]({msg_link})'.format(
-            username=msg.frm.nick,
-            backend=self.bot_config.BACKEND,
-            msg_link=message_link(self, msg)
-        )
+
+        extra_parts = []
+        if msg.frm.nick:
+            extra_parts.append('by @{}'.format(msg.frm.nick))
+        msg_link = message_link(self, msg)
+        if msg_link:
+            extra_parts.append(
+                'at [{backend}]({msg_link})'.format(
+                    backend=self.bot_config.BACKEND,
+                    msg_link=message_link(self, msg)
+                )
+            )
+        else:
+            extra_parts.append('on {}'.format(self.bot_config.BACKEND))
+
+        extra_msg = '\nOpened {}'.format(' '.join(extra_parts))
 
         if repo_name in self.REPOS:
             repo = self.REPOS[repo_name]

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -11,7 +11,7 @@ from IGitt.GitHub.GitHubMergeRequest import GitHubMergeRequest
 from IGitt.GitLab.GitLabMergeRequest import GitLabMergeRequest
 from IGitt.GitHub.GitHubIssue import GitHubIssue
 
-from errbot.backends.test import TestBot
+from errbot.backends.test import Message, TestBot
 
 import plugins.labhub
 from plugins.labhub import LabHub
@@ -88,7 +88,6 @@ class TestLabHub(unittest.TestCase):
         plugins.labhub.GitHubToken.assert_called_with(None)
         plugins.labhub.GitLabPrivateToken.assert_called_with(None)
 
-
         labhub.REPOS = {'repository': self.mock_repo,
                         'repository.github.io': self.mock_repo}
 
@@ -96,14 +95,19 @@ class TestLabHub(unittest.TestCase):
                               'Here you go')
 
         labhub.REPOS['repository'].create_issue.assert_called_once_with(
-            'this is the title', 'bo\ndy\nOpened by @None at [text]()'
+            'this is the title', 'bo\ndy\nOpened on text'
         )
 
-        testbot.assertCommand('!new issue repository.github.io another title\nand body',
-                              'Here you go')
+        msg = Message('!new issue repository.github.io another title\nand body',
+                      'Here you go')
+        msg.extras['url'] = 'http://example.com'
+        msg.frm = testbot.bot.build_identifier('Jo')
+        msg.frm._nick = 'jo'
+
+        testbot.bot.callback_message(msg)
 
         labhub.REPOS['repository.github.io'].create_issue.assert_called_with(
-            'another title', 'and body\nOpened by @None at [text]()'
+            'another title', 'and body\nOpened by @jo at [text](http://example.com/)'
         )
 
         testbot.assertCommand('!new issue coala title', 'repository that does not exist')

--- a/utils/backends.py
+++ b/utils/backends.py
@@ -12,11 +12,7 @@ def message_link(bot, msg):
     if backend == 'gitter':
         return 'https://gitter.im/{uri}?at={idd}'.format(uri=msg.frm.room.uri,
                                                          idd=msg.extras['id'])
-    elif backend == 'slack':
+    elif 'url' in msg.extras:
         return msg.extras['url']
-    elif backend == 'telegram':
-        return ''
-    elif backend == 'text':
-        return ''
     else:
-        raise NotImplementedError
+        return None


### PR DESCRIPTION
Some backends do not provide usernames or msg links.

Zulip and Slack both using msg.extra['url'], and a
patch is pending for the gitter backend to follow suite.
https://github.com/errbotio/err-backend-gitter/pull/32

Fixes https://github.com/coala/corobo/issues/392
Related to https://github.com/coala/corobo/issues/255
