### PR TITLE
labhub.py: Get author from IGitt

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -214,12 +214,6 @@ class LabHub(BotPlugin):
             return 'Repository doesn\'t exist.'
         else:
             current_labels = list(mr.labels)
-            data = mr.data
-            login = None
-            if 'user' in data:
-                login = data['user']['login']
-            elif 'author' in data:
-                login = data['author']['username']
             if state == 'wip':
                 pending_labels = ['process/pending_review',
                                   'process/pending review']
@@ -230,9 +224,9 @@ class LabHub(BotPlugin):
                 mr.labels = current_labels
 
                 ping = ''
-                if login is not None:
+                if mr.author is not None:
                     ping = ('\n@{user_login}, please check your pull '
-                            'request.'.format(user_login=login))
+                            'request.'.format(user_login=mr.author))
 
                 return ('The pull request {mr_link} is marked *work in progress'
                         '*. Use `{bot_prefix} mark pending` or push to your '

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/errbotio/errbot@c2639879d4c298933cdf406193de5a5e626db12b
 wolframalpha
 github3.py
-IGitt==0.4.1.dev20170812210154
+IGitt==0.4.1.dev20171129151739
 gitpython
 vcrpy
 ramlient

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -228,8 +228,8 @@ class TestLabHub(unittest.TestCase):
         mock_gitlab_mr = create_autospec(GitLabMergeRequest)
         mock_github_mr.labels = PropertyMock()
         mock_gitlab_mr.labels = PropertyMock()
-        mock_github_mr.data = { 'user': { 'login': 'johndoe' } }
-        mock_gitlab_mr.data = { 'author': { 'username': 'johndoe' } }
+        mock_github_mr.author = 'johndoe'
+        mock_gitlab_mr.author = 'johndoe'
         cmd_github = '!mark {} https://github.com/{}/{}/pull/{}'
         cmd_gitlab = '!mark {} https://gitlab.com/{}/{}/merge_requests/{}'
 


### PR DESCRIPTION
This will get the author from IGitt as opposed to checking the raw data
from GitHub and GitLab.

Fixes https://github.com/coala/corobo/issues/419

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
