### PR TITLE
git_stats.py: New plugin

### DIFF
--- a/plugins/git_stats.plug
+++ b/plugins/git_stats.plug
@@ -1,0 +1,11 @@
+[Core]
+name = git_stats
+module = git_stats
+
+[Documentation]
+description = GitHub and GitLub statistics
+
+[Python]
+version = 3
+
+[Errbot]

--- a/plugins/git_stats.py
+++ b/plugins/git_stats.py
@@ -1,0 +1,78 @@
+import datetime
+import re
+from shutil import rmtree
+
+from errbot import re_botcmd
+
+from plugins.labhub import LabHub
+
+
+class GitStats(LabHub):
+    """GitHub and GitLab statistics"""  # Ignore QuotesBear
+
+    PR_LABELS = ('process/approved',
+                 'process/pending review',
+                 'process/pending-review'
+                 )
+
+    def __init__(self, bot, name=None):
+        super().__init__(bot, name)
+
+    @re_botcmd(pattern=r'mergable\s+([^/]+)',  # Ignore PyCodeStyleBear
+               re_cmd_name_help='pr list <repo>',
+               flags=re.IGNORECASE)
+    def pr_list(self, msg, match):
+        """List PRs ready to be merged."""  # Ignore QuotesBear
+        repo_name = match.groups(1)[0]
+
+        try:
+            merge_requests = self.REPOS[repo_name].merge_requests()
+        except KeyError:
+            return "Repository doesn't exist."
+
+        checks = []
+
+        def check_mr(func):
+            checks.append(func)
+            return func
+
+        @check_mr
+        def check_labels(merge_request):
+            labels = set(merge_request.labels)
+            if labels.intersection(self.PR_LABELS):
+                return True
+            return False
+
+        @check_mr
+        def check_state(merge_request):
+            if merge_request.state == 'open':
+                return True
+            return False
+
+        @check_mr
+        def check_rebased(merge_request):
+            repo, tempdir = merge_request.repository.get_clone()
+            head_sha = repo.head.commit.hexsha
+            rmtree(tempdir)
+            if merge_request.base.sha == head_sha:
+                return True
+            return False
+
+        def merge_ready(merge_request):
+            for chk in checks:
+                if not chk(merge_request):
+                    return False
+            return True
+
+        ready_to_merge = []
+        for mr in merge_requests:
+            if merge_ready(mr):
+                ready_to_merge.append(mr)
+        if len(ready_to_merge) == 0:
+            return "No merge-ready PRs!"
+        else:
+            now = datetime.datetime.now()
+            response = "PRs ready to be merged:\n\n"
+            for mr in sorted(ready_to_merge, key=lambda x: now - x.created):
+                response += '{}\n'.format(mr.url)
+            return response

--- a/tests/git_stats_test.py
+++ b/tests/git_stats_test.py
@@ -1,0 +1,103 @@
+import logging
+from tempfile import mkdtemp
+import unittest
+from unittest.mock import Mock, MagicMock, create_autospec, PropertyMock, patch
+
+from IGitt.GitHub.GitHubMergeRequest import GitHubMergeRequest
+from IGitt.GitLab.GitLabMergeRequest import GitLabMergeRequest
+from IGitt.GitHub.GitHubIssue import GitHubIssue
+from IGitt.GitLab.GitLabIssue import GitLabIssue
+from git import Repo
+
+import github3
+import IGitt
+import plugins.git_stats
+from tests.helper import plugin_testbot
+
+
+class TestGitStats(unittest.TestCase):
+
+    def setUp(self):
+        plugins.git_stats.github3 = create_autospec(github3)
+        self.mock_org = create_autospec(github3.orgs.Organization)
+        self.mock_gh = create_autospec(github3.GitHub)
+        self.mock_repo = create_autospec(IGitt.GitHub.GitHub.GitHubRepository)
+        plugins.git_stats.github3.login.return_value = self.mock_gh
+        self.mock_gh.organization.return_value = self.mock_org
+        plugins.git_stats.github3.organization.return_value = self.mock_org
+
+    def test_pr_list(self):
+        git_stats, testbot = plugin_testbot(plugins.git_stats.GitStats, logging.ERROR)
+        git_stats.activate()
+
+        git_stats.REPOS = {'test': self.mock_repo}
+        mock_github_mr = create_autospec(GitHubMergeRequest)
+        mock_gitlab_mr = create_autospec(GitLabMergeRequest)
+        mock_github_issue = create_autospec(GitHubIssue)
+        mock_gitlab_issue = create_autospec(GitLabIssue)
+        mock_github_mr.closes_issue = mock_github_issue
+        mock_gitlab_mr.closes_issue = mock_gitlab_issue
+        mock_github_mr.repository = self.mock_repo
+        mock_gitlab_mr.repository = self.mock_repo
+        mock_github_mr.url = 'http://www.example.com/'
+        mock_gitlab_mr.url = 'http://www.example.com/'
+        mock_repo_obj = create_autospec(Repo)
+        cmd_github = '!mergable {}'
+        cmd_gitlab = '!mergable {}'
+
+        self.mock_repo.merge_requests.return_value = [mock_github_mr]
+
+        # Non-existing repo
+        testbot.assertCommand(cmd_github.format('b'),
+                              'Repository doesn\'t exist.')
+        testbot.assertCommand(cmd_gitlab.format('b'),
+                              'Repository doesn\'t exist.')
+
+        # PR is suitable
+        mock_github_mr.labels = ['process/approved', 'difficulty/newcomer']
+        mock_gitlab_mr.labels = ['process/approved', 'difficulty/newcomer']
+        mock_github_mr.state = 'open'
+        mock_gitlab_mr.state = 'open'
+        self.mock_repo.get_clone.return_value = (mock_repo_obj, mkdtemp('mock_repo/'))
+        mock_repo_obj.head.commit.hexsha = '1'
+        mock_github_mr.base.sha = '1'
+        mock_gitlab_mr.base.sha = '1'
+        testbot.assertCommand(cmd_github.format('test'),
+                              'PRs ready to be merged:\n '
+                              'http://www.example.com/')
+        self.mock_repo.get_clone.return_value = (mock_repo_obj, mkdtemp('mock_repo/'))
+        testbot.assertCommand(cmd_gitlab.format('test'),
+                              'PRs ready to be merged:\n '
+                              'http://www.example.com/')
+
+        # PR is not suitable (wrong labels)
+        mock_github_mr.labels = ['process/wip', 'difficulty/newcomer']
+        mock_gitlab_mr.labels = ['process/wip', 'difficulty/newcomer']
+        self.mock_repo.get_clone.return_value = (mock_repo_obj, mkdtemp('mock_repo/'))
+        testbot.assertCommand(cmd_github.format('test'),
+                              'No merge-ready PRs!')
+        self.mock_repo.get_clone.return_value = (mock_repo_obj, mkdtemp('mock_repo/'))
+        testbot.assertCommand(cmd_gitlab.format('test'),
+                              'No merge-ready PRs!')
+        mock_github_mr.labels = ['process/approved', 'difficulty/newcomer']
+        mock_gitlab_mr.labels = ['process/approved', 'difficulty/newcomer']
+
+        # PR is not suitable (needs rebase)
+        mock_repo_obj.head.commit.hexsha = '2'
+        self.mock_repo.get_clone.return_value = (mock_repo_obj, mkdtemp('mock_repo/'))
+        testbot.assertCommand(cmd_github.format('test'),
+                              'No merge-ready PRs!')
+        self.mock_repo.get_clone.return_value = (mock_repo_obj, mkdtemp('mock_repo/'))
+        testbot.assertCommand(cmd_gitlab.format('test'),
+                              'No merge-ready PRs!')
+        mock_repo_obj.head.commit.hexsha = '1'
+
+        # PR is not suitable (already closed)
+        mock_github_mr.state = 'closed'
+        mock_gitlab_mr.state = 'closed'
+        self.mock_repo.get_clone.return_value = (mock_repo_obj, mkdtemp('mock_repo/'))
+        testbot.assertCommand(cmd_github.format('test'),
+                              'No merge-ready PRs!')
+        self.mock_repo.get_clone.return_value = (mock_repo_obj, mkdtemp('mock_repo/'))
+        testbot.assertCommand(cmd_gitlab.format('test'),
+                              'No merge-ready PRs!')


### PR DESCRIPTION
labhub.py: list rebased PRs

Add list mergre-ready PRs command
'pr list \<complete-repo-URL\>'.
Lists open PRs, which don't need
rebase and have 'process/approved'
or 'process/review_pending' labels.

Closes https://github.com/coala/corobo/issues/171

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
