### PR TITLE
creating chat_err_monitor.py to prevent people from using 'sir' and '…

### DIFF
--- a/plugins/chat_error_monitor.py
+++ b/plugins/chat_error_monitor.py
@@ -9,10 +9,20 @@ class Coala_lowercase_c(BotPlugin):
 
     def callback_message(self, msg):
         emots = [':(', ':angry:', ':confounded:',
-                 ':disappointed:', ':triumph:']
+                 ':disappointed:', ':triumph:' , ':D']
 
         match_coala = re.search(r'(?:^|[^\w])C+[Oo]+[Aa]+[Ll]+[Aa]+(?:$|[^\w])',
                                 msg.body)
+        match_sir = 'sir' in msg.body
+        if match_sir:
+            self.send(
+                msg.frm,
+                '@{}, please do not use the word \'sir\' '
+                'and be more informal to have more fun'.format(
+                    msg.frm.nick, emots[5]
+                )
+            )
+            
         if match_coala:
             self.send(
                 msg.frm,


### PR DESCRIPTION
…C' in 'Corobo'

Ask people to not use 'sir' when they do :D.#337. The file was renamed.

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
