### PR TITLE
creating coala_monitor.py to avoid 'sir' and 'Corobo'

### DIFF
--- a/plugins/coala_monitor.py
+++ b/plugins/coala_monitor.py
@@ -17,7 +17,7 @@ class Coala_lowercase_c(BotPlugin):
         if match_sir:
             self.send(
                 msg.frm,
-                '@{}, Do not use \'sir\', so u can sound friendly.'.format(
+                '@{}, Do not use \'sir\', so u sound friendly.'.format(
                     msg.frm.nick, emots[5]
                 )
             )

--- a/plugins/coala_monitor.py
+++ b/plugins/coala_monitor.py
@@ -9,10 +9,18 @@ class Coala_lowercase_c(BotPlugin):
 
     def callback_message(self, msg):
         emots = [':(', ':angry:', ':confounded:',
-                 ':disappointed:', ':triumph:']
+                 ':disappointed:', ':triumph:', ':D']
 
         match_coala = re.search(r'(?:^|[^\w])C+[Oo]+[Aa]+[Ll]+[Aa]+(?:$|[^\w])',
                                 msg.body)
+        match_sir = 'sir' in msg.body
+        if match_sir:
+            self.send(
+                msg.frm,
+                '@{}, Do not use \'sir\', so u can sound friendly.'.format(
+                    msg.frm.nick, emots[5]
+                )
+            )
         if match_coala:
             self.send(
                 msg.frm,


### PR DESCRIPTION
creating chat_err_monitor.py to prevent people from using 'sir' for to sound more friendlier. #431. :D

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
