### PR TITLE
requirments.txt: Pin pyopenssl before 17.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pyopenssl<17.5
 git+https://github.com/errbotio/errbot@c2639879d4c298933cdf406193de5a5e626db12b
 wolframalpha
 github3.py


### PR DESCRIPTION
The latest release is causing connection problems
on corobo only.

Fixes https://github.com/coala/corobo/issues/433

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
