### PR TITLE
git_stats.py: Hotfix

### DIFF
--- a/plugins/git_stats.py
+++ b/plugins/git_stats.py
@@ -38,7 +38,7 @@ class GitStats(LabHub):
 
         @check_mr
         def check_labels(merge_request):
-            labels = set(merge_request.labels)
+            labels = {*merge_request.labels}
             if labels.intersection(self.PR_LABELS):
                 return True
             return False


### PR DESCRIPTION
git_stats.py: Hotfix

Dealing with 'set object is
not callable' error

Closes https://github.com/coala/corobo/issues/438

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
