### PR TITLE
git_stats: Do not subclass LabHub

### DIFF
--- a/plugins/git_stats.plug
+++ b/plugins/git_stats.plug
@@ -1,6 +1,7 @@
 [Core]
 name = git_stats
 module = git_stats
+DependsOn = LabHub
 
 [Documentation]
 description = GitHub and GitLab statistics

--- a/plugins/git_stats.py
+++ b/plugins/git_stats.py
@@ -2,12 +2,10 @@ import datetime
 import re
 from shutil import rmtree
 
-from errbot import re_botcmd
-
-from plugins.labhub import LabHub
+from errbot import BotPlugin, re_botcmd
 
 
-class GitStats(LabHub):
+class GitStats(BotPlugin):
     """GitHub and GitLab statistics"""  # Ignore QuotesBear
 
     PR_LABELS = ('process/approved',
@@ -15,8 +13,9 @@ class GitStats(LabHub):
                  'process/pending-review'
                  )
 
-    def __init__(self, bot, name=None):
-        super().__init__(bot, name)
+    def activate(self):
+        super().activate()
+        self.REPOS = self.get_plugin('LabHub').REPOS
 
     @re_botcmd(pattern=r'mergable\s+([^/]+)',  # Ignore PyCodeStyleBear
                re_cmd_name_help='pr list <repo>',

--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -20,9 +20,7 @@ class LabHub(BotPlugin):
     GH_ORG_NAME = constants.GH_ORG_NAME
     GL_ORG_NAME = constants.GL_ORG_NAME
 
-    def __init__(self, bot, name=None):
-        super().__init__(bot, name)
-
+    def activate(self):
         teams = dict()
         try:
             gh = github3.login(token=os.environ.get('GH_TOKEN'))
@@ -62,6 +60,7 @@ class LabHub(BotPlugin):
             self.REPOS.update(self.gl_repos)
 
         self.invited_users = set()
+        super().activate()
 
     @property
     def TEAMS(self):


### PR DESCRIPTION
Use proper plugin dependency system.

Fixes https://github.com/coala/corobo/issues/441

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
