### PR TITLE
creating no_sir.py: to tell users to not use 'sir'

### DIFF
--- a/plugins/no_sir.py
+++ b/plugins/no_sir.py
@@ -1,0 +1,13 @@
+from errbot import BotPlugin
+class no_sir(BotPlugin):
+    """do not use sir to sound more friendly"""  # Ignore QuotesBear
+
+    def callback_message(self, msg):
+        emots = [':D']
+        if match_sir:
+            self.send(
+                msg.frm,
+                '@{}, donot use \'sir\' in ur conversation. {}'.format(
+                    msg.frm.nick, emots[0]
+                )
+            )


### PR DESCRIPTION
Ask people to not use 'sir' when they do #337.

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
