### PR TITLE
creating no_sir.plug: plug file for no_sir.py

### DIFF
--- a/plugins/no_sir.plug
+++ b/plugins/no_sir.plug
@@ -1,0 +1,9 @@
+[Core]
+name = no_sir
+module = no_sir
+
+[Documentation]
+description = Ask people to not use 'sir' when they do.
+
+[Python]
+version = 3


### PR DESCRIPTION
no_sir.py is  to tell users to not use 'sir' when they do. #337

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
