### PR TITLE
.coafile: Fix a typo

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -27,7 +27,7 @@ bears = LineLengthBear
 [all.links]
 bears = InvalidLinkBear
 
-[commits]
+[commit]
 bears = GitCommitBear
 shortlog_regex = ([^:]*|[^:]+[^ ]: [A-Z0-9*].*)
 shortlog_trailing_period = False


### PR DESCRIPTION
Changes `[commits]` to `[commit]`.

Closes https://github.com/coala/corobo/issues/451

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
