### PR TITLE
adding rage emoji to be commented when 'Coala' is used in chat

### DIFF
--- a/plugins/coala_lowercase_c.py
+++ b/plugins/coala_lowercase_c.py
@@ -9,7 +9,7 @@ class Coala_lowercase_c(BotPlugin):
 
     def callback_message(self, msg):
         emots = [':(', ':angry:', ':confounded:',
-                 ':disappointed:', ':triumph:']
+                 ':disappointed:', ':triumph:', ':rage:']
 
         match_coala = re.search(r'(?:^|[^\w])C+[Oo]+[Aa]+[Ll]+[Aa]+(?:$|[^\w])',
                                 msg.body)


### PR DESCRIPTION
rage emoji is added to the coala_lowercase_c.py for cEP lowercase message. the emoji is used when capital C is used in 'coala' by corobo.closes #229

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
