### PR TITLE
changes to labhub.py :to add an extra message when newcomer tries to assign medium issues

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -318,7 +318,12 @@ class LabHub(BotPlugin):
             'corobo will invite you.'.format(self.GH_ORG_NAME),
             '- A newcomer cannot be assigned to an issue with a difficulty '
             'level higher than newcomer or low difficulty.',
-            '- A newcomer cannot be assigned to unlabelled issues.'
+            '- A newcomer cannot be assigned to unlabelled issues.',
+            '- You cannot be assigned to a medium level issue'
+            'if you are not a developer.'
+            'If you want to be a developer you need '
+            'to complete all the 5 tasks in '
+            'http://api.coala.io/en/latest/Developers/Newcomers_Guide.html'
         ]
 
         try:


### PR DESCRIPTION
This mentions that the medium level and unlabelled issues cannot be
assigned to newcomers and they need to complete the developer
process to get themselves assign such issues.

closes #296

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
