### PR TITLE
config.py: Restrict private issue creation

### DIFF
--- a/config.py
+++ b/config.py
@@ -56,6 +56,7 @@ ROOMS_TO_JOIN = (
 CHATROOM_PRESENCE = os.environ.get('ROOMS', '').split() or ROOMS_TO_JOIN
 
 ACCESS_CONTROLS = {'render test': {
-    'allowrooms': ('coala/cobot-test', 'coala/corobo',)}, }
+    'allowrooms': ('coala/cobot-test', 'coala/corobo',)},
+    'LabHub:create_issue_cmd': {'allowprivate': False}}
 
 AUTOINSTALL_DEPS = True


### PR DESCRIPTION
config.py: Restrict private issue creation

Don't allow users to
create issues in private conversations
with corobo

Fixes https://github.com/coala/corobo/issues/391

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
