### PR TITLE
.travis.yml: Install using pip once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,22 @@ addons:
       - libssl-dev
       - python3-dev
 
+before_install:
+  - cp requirements.txt requirements.orig
+  - printf '%s\n%s\n%s\n%s\n'
+           "git+https://github.com/coala/coala"
+           "git+https://github.com/coala/coala-bears"
+           "$(cat test-requirements.txt)"
+           "$(cat requirements.txt)"
+           > requirements.txt
+
 before_script:
-  - pip install coala-bears
-  - pip install -r requirements.txt
-  - pip install -r test-requirements.txt
+  # Docker will fail to build if coala-bears is included
+  # as one of the bears depends on its own version of
+  # libbrotli which doesnt compile without a lot of deps.
+  - mv requirements.orig requirements.txt
 
 script:
-  - sed -i.bak '/bears = GitCommitBear/d' .coafile
   - coala --non-interactive -V
   - python -m pytest
   - docker build -t "corobo" .

--- a/tests/answer_test.py
+++ b/tests/answer_test.py
@@ -1,7 +1,6 @@
 import vcr
 import requests_mock
 
-import plugins.answer
 from tests.isolated_testcase import IsolatedTestCase
 
 

--- a/tests/lmgtfy_test.py
+++ b/tests/lmgtfy_test.py
@@ -1,9 +1,4 @@
-import errbot.rendering
-
-from plugins.lmgtfy import Lmgtfy
 from tests.isolated_testcase import IsolatedTestCase
-
-text = errbot.rendering.text()
 
 
 class LmgtfyTest(IsolatedTestCase):

--- a/tests/the_rules_test.py
+++ b/tests/the_rules_test.py
@@ -1,4 +1,3 @@
-from plugins.the_rules import The_rules
 from tests.isolated_testcase import IsolatedTestCase
 
 

--- a/tests/wolfram_alpha_test.py
+++ b/tests/wolfram_alpha_test.py
@@ -1,6 +1,5 @@
 import vcr
 
-from plugins.wolfram_alpha import WolframAlpha
 from tests.isolated_testcase import IsolatedTestCase
 
 my_vcr = vcr.VCR(match_on=['method', 'scheme', 'host', 'port', 'path'],


### PR DESCRIPTION
The default `install:` phase of Travis CI does
`pip install -r requirements.txt`, which was
duplicated by the custom `before_script:` block.

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
