### PR TITLE
Ban a member

### DIFF
--- a/config.py
+++ b/config.py
@@ -94,6 +94,8 @@ ROOMS_TO_JOIN = (
 
 CHATROOM_PRESENCE = os.environ.get('ROOMS', '').split() or ROOMS_TO_JOIN
 
+USERS_TO_BLACKLIST = []
+
 ACCESS_CONTROLS = {'render test': {
     'allowrooms': ('coala/cobot-test', 'coala/corobo',)},
     'LabHub:*': {'allowprivate': False}}

--- a/plugins/templates/labhub/errors/ban-maintainer.jinja2.md
+++ b/plugins/templates/labhub/errors/ban-maintainer.jinja2.md
@@ -1,0 +1,1 @@
+@{{ target }}, you can\'t ban a maintainer.

--- a/utils/filters.py
+++ b/utils/filters.py
@@ -21,6 +21,7 @@ class Filters(BotPlugin):
             if cmd in commands and msg.frm.room.uri == room:
                 return None, None, None
         return msg, cmd, args
+    
 
     @cmdfilter
     def filter_ignored_users(self, msg, cmd, args, dry_run):


### PR DESCRIPTION
Add a command to remove a member from newcomer team,
blacklist member from using corobo. Limit usage of
this command to mainatiners and not allowed in
private chat

Closes https://github.com/coala/corobo/issues/462

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
