### PR TITLE
pitchfork.py: Limit pitchfork to developers

### DIFF
--- a/plugins/pitchfork.plug
+++ b/plugins/pitchfork.plug
@@ -1,6 +1,7 @@
 [Core]
 name = pitchfork
 module = pitchfork
+DependsOn = LabHub
 
 [Documentation]
 description = To pitchfork users down to ...

--- a/plugins/pitchfork.py
+++ b/plugins/pitchfork.py
@@ -17,23 +17,31 @@ class Pitchfork(BotPlugin):
         """
         match = re.match(r'@?([\w-]+)(?:\s+(?:down\s+)?to\s+(.+))?$',
                          arg)
+        GH_ORG_NAME = self.get_plugin('LabHub').GH_ORG_NAME
+        teams = self.get_plugin('LabHub').TEAMS()
+        issuer = msg.frm.nick
         if match:
-            user = match.group(1)
-            place = match.group(2) if match.group(2) else 'offtopic'
-            return textwrap.dedent((
-                string.Template("""
-                    @$user, you are being pitchforked down to $place
-                    ```
-                                                          .+====----->
-                                                           \('
-                    =====================================<%{%{%{>>+===---> $user
-                                                           /(,
-                                                          .+====----->
-                    ```
-                """).substitute(user=user,
-                                place=('[offtopic]('
-                                       'https://gitter.im/coala/coala/offtopic)'
-                                       if place == 'offtopic' else place))
-                ))
+            if teams[GH_ORG_NAME + ' developers'].is_member(issuer):
+                user = match.group(1)
+                place = match.group(2) if match.group(2) else 'offtopic'
+                return textwrap.dedent((
+                    string.Template("""
+                        @$user, you are being pitchforked down to $place
+                        ```
+                                                              .+====----->
+                                                               \('
+                        ================================<%{%{%{>>+===---> $user
+                                                               /(,
+                                                              .+====----->
+                        ```
+                    """).substitute(user=user,
+                                    place=('[offtopic]('
+                                           'https://gitter.im/coala/'
+                                           'coala/offtopic)'
+                                           if place == 'offtopic' else place))
+                    ))
+            else:
+                return ('@{}, you are not a developer, only developers can'
+                        ' invite other people. Nice try :poop:'.format(issuer))
         else:
             return "Usage: `pitchfork user [[down] to place]`"


### PR DESCRIPTION
Limits the use of pitchfork command to developers

Closes https://github.com/coala/corobo/issues/358

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
