### PR TITLE
labhub: Adapt to the modified newcomer process

### DIFF
--- a/plugins/templates/hello_world.jinja2.md
+++ b/plugins/templates/hello_world.jinja2.md
@@ -1,0 +1,7 @@
+Welcome @{{ target }}! :tada:
+
+Please go through https://coala.io/newcomer (skip instructions about using corobo). Find your first issue and ask one of the maintainers to assign you to it and we'll invite you to the org. Most issues will be explained there and in linked pages - it will save you a lot of time, just read it. *Really.*
+
+*Do not take an issue if you don't understand it on your own.* Especially if you are new you have to be aware that getting started with an open source community is not trivial: you will have to work hard and most likely become a better coder than you are now just as we all did.
+
+Don't get us wrong: we are *very* glad to have you with us on this journey into open source! We will also be there for you at all times to help you with actual problems. :)

--- a/plugins/templates/labhub/promotions/newcomers.jinja2.md
+++ b/plugins/templates/labhub/promotions/newcomers.jinja2.md
@@ -1,9 +1,1 @@
-Welcome @{{ target }}! :tada:
-
-We've just sent you an invite via email. Please accept it before proceeding forward.
-
-To get started, please follow our [newcomers guide] (https://coala.io/newcomer). Most issues will be explained there and in linked pages - it will save you a lot of time, just read it. *Really.*
-
-*Do not take an issue if you don't understand it on your own.* Especially if you are new you have to be aware that getting started with an open source community is not trivial: you will have to work hard and most likely become a better coder than you are now just as we all did.
-
-Don't get us wrong: we are *very* glad to have you with us on this journey into open source! We will also be there for you at all times to help you with actual problems. :)
+@{{ target }} We've just sent you an invite via email. Please accept it before proceeding forward. Please go through [newcomers guide](https://coala.io/newcomer) first, if you have any doubts, they are likely to be solved there. Use relevant channels for help if needed. You have already selected the issue, assign yourself to it using corobo and you can start working on it! :D

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -69,12 +69,11 @@ class TestLabHub(unittest.TestCase):
         labhub = testbot.bot.plugin_manager.get_plugin_obj_by_name('LabHub')
         labhub.TEAMS = teams
         self.mock_team.is_member.return_value = False
-        testbot.assertCommand('hello, world', 'newcomer')
+        testbot.assertCommand('hello, world', 'newcomer', timeout=10000)
         # Since the user won't be invited again, it'll timeout waiting for a
         # response.
         with self.assertRaises(queue.Empty):
             testbot.assertCommand('helloworld', 'newcomer')
-        self.mock_team.invite.assert_called_with(None)
 
     def test_create_issue_cmd(self):
         plugins.labhub.GitHub = create_autospec(IGitt.GitHub.GitHub.GitHub)
@@ -312,25 +311,3 @@ class TestLabHub(unittest.TestCase):
             testbot.assertCommand('!pr stats 3hours',
                                   '10 PRs opened in last 3 hours\n'
                                   'The community is on fire')
-
-    def test_invite_me(self):
-        teams = {
-            'coala maintainers': self.mock_team,
-            'coala newcomers': self.mock_team,
-            'coala developers': self.mock_team
-        }
-
-        labhub, testbot = plugin_testbot(plugins.labhub.LabHub, logging.ERROR)
-        labhub.activate()
-        labhub._teams = teams
-
-        plugins.labhub.os.environ['GH_TOKEN'] = 'patched?'
-        testbot.assertCommand('!invite me',
-                              'We\'ve just sent you an invite')
-        with self.assertRaises(queue.Empty):
-            testbot.pop_message()
-
-        testbot.assertCommand('!hey there invite me',
-                              'Command \"hey\" / \"hey there\" not found.')
-        with self.assertRaises(queue.Empty):
-             testbot.pop_message()


### PR DESCRIPTION
- `invite me` variation of invite command is removed.
- "Hello world"s no longer trigger invites.
- Newcomer invitation message is changed to show the modification in the
  newcomer process.

Closes https://github.com/coala/corobo/issues/476

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
