### PR TITLE
labhub: Use web_url instead of url

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -157,7 +157,7 @@ class LabHub(BotPlugin):
         if repo_name in self.REPOS:
             repo = self.REPOS[repo_name]
             iss = repo.create_issue(iss_title, iss_description + extra_msg)
-            return 'Here you go: {}'.format(iss.url)
+            return 'Here you go: {}'.format(iss.web_url)
         else:
             return tenv().get_template(
                 'labhub/errors/no-repository.jinja2.md'
@@ -228,7 +228,7 @@ class LabHub(BotPlugin):
                         '*. Use `{bot_prefix} mark pending` or push to your '
                         'branch if feedback from the community is needed '
                         'again.{ping}'.format(
-                            mr_link=mr.url,
+                            mr_link=mr.web_url,
                             bot_prefix=self.bot_config.BOT_PREFIX,
                             ping=ping)
                         )
@@ -243,7 +243,7 @@ class LabHub(BotPlugin):
                         'so you will get feedback from the community. Use '
                         '`{bot_prefix} mark wip` if there are known issues that'
                         ' should be corrected by the author.'.format(
-                            mr_link=mr.url,
+                            mr_link=mr.web_url,
                             bot_prefix=self.bot_config.BOT_PREFIX)
                         )
 

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -251,6 +251,9 @@ class TestLabHub(unittest.TestCase):
         testbot.assertCommand('!mark wip https://gitlab.com/a/b/merge_requests/2',
                               'Repository doesn\'t exist.')
 
+        mock_github_mr.web_url = 'https://github.com/coala/a/pull/23'
+        mock_gitlab_mr.web_url = 'https://gitlab.com/coala/a/merge_requests/23'
+
         # mark wip
         mock_github_mr.labels = ['process/pending review']
         mock_gitlab_mr.labels = ['process/pending review']
@@ -258,11 +261,15 @@ class TestLabHub(unittest.TestCase):
                               'marked work in progress')
         testbot.assertCommand(cmd_github.format('wip', 'coala', 'a', '23'),
                               '@johndoe, please check your pull request')
+        testbot.assertCommand(cmd_github.format('wip', 'coala', 'a', '23'),
+                              'https://github.com/coala/a/pull/23')
 
         self.mock_repo.get_mr.return_value = mock_gitlab_mr
 
         testbot.assertCommand(cmd_gitlab.format('wip', 'coala', 'a', '23'),
                               '@johndoe, please check your pull request')
+        testbot.assertCommand(cmd_gitlab.format('wip', 'coala', 'a', '23'),
+                              'https://gitlab.com/coala/a/merge_requests/23')
 
         self.mock_repo.get_mr.return_value = mock_github_mr
 


### PR DESCRIPTION
Use web_url to get HTML URL instead of API URL.
Add basic tests for the same.

As @meetmangukiya already noted on [gitter](https://gitter.im/coala/corobo?at=5a20549b71ad3f87364d83c4), it's mildly redundant to add tests(since they mock the property being tested)

Closes https://github.com/coala/corobo/issues/426

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.