### PR TITLE
git_stats.plug: Fix spelling from 'GitLub' to 'GitLab'

### DIFF
--- a/plugins/git_stats.plug
+++ b/plugins/git_stats.plug
@@ -3,7 +3,7 @@ name = git_stats
 module = git_stats
 
 [Documentation]
-description = GitHub and GitLub statistics
+description = GitHub and GitLab statistics
 
 [Python]
 version = 3


### PR DESCRIPTION
Change spelling on line 6 of git_stats.plug file from GitLub to GitLab
fixes <https://github.com/coala/corobo/issues/490>

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
