### PR TITLE
Rename COBOT_ROOT to BOT_ROOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3-alpine
 
-ENV COBOT_ROOT=/opt/errbot
+ENV BOT_ROOT=/opt/errbot
 
-ADD requirements.txt $COBOT_ROOT/requirements.txt
+ADD requirements.txt $BOT_ROOT/requirements.txt
 
 RUN apk add --no-cache libffi openssl git \
     && apk add --no-cache --virtual .build-deps \
@@ -10,16 +10,16 @@ RUN apk add --no-cache libffi openssl git \
            libc-dev \
            libffi-dev \
            openssl-dev \
-    && pip install -r $COBOT_ROOT/requirements.txt \
+    && pip install -r $BOT_ROOT/requirements.txt \
     && pip install slackclient python-telegram-bot \
     && apk del .build-deps
 
-ADD . $COBOT_ROOT
+ADD . $BOT_ROOT
 
 RUN addgroup -S errbot \
-    && adduser -h $COBOT_ROOT -G errbot -S errbot \
-    && mkdir -p $COBOT_ROOT/data $COBOT_ROOT/plugins \
-    && chown -R errbot:errbot $COBOT_ROOT
+    && adduser -h $BOT_ROOT -G errbot -S errbot \
+    && mkdir -p $BOT_ROOT/data $BOT_ROOT/plugins \
+    && chown -R errbot:errbot $BOT_ROOT
 
 USER errbot
 WORKDIR /opt/errbot

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Read more about what `corobo` could do for you
 
 ## Environment Variables
 
-1. `COBOT_ROOT` - absolute path of the project root.
+1. `BOT_ROOT` - absolute path of the project root.
 2. `BOT_PREFIX` - prefix to use for issuing bot commands.
 3. `BOT_ADMINS` - Admins of the errbot instance.
 4. `ROOMS` - Space separated list of rooms to join on startup. e.g.

--- a/config.py
+++ b/config.py
@@ -1,7 +1,15 @@
 import logging
 import os
 
-COBOT_ROOT = os.environ.get('COBOT_ROOT', os.getcwd())
+BOT_ROOT_KEY = 'BOT_ROOT'
+
+if 'COBOT_ROOT' in os.environ and BOT_ROOT_KEY not in os.environ:
+    logging.warning(
+        "Environment variable COBOT_ROOT is deprecated, use {} instead."
+        .format(BOT_ROOT_KEY))
+    BOT_ROOT_KEY = 'COBOT_ROOT'
+BOT_ROOT = os.environ.get(BOT_ROOT_KEY, os.getcwd())
+
 
 _BOT_IDENTITY_KEYS = (
     'endpoint',
@@ -34,7 +42,7 @@ if not BACKEND:
         BACKEND = 'Text'
 
 if BACKEND == 'Gitter':
-    BOT_EXTRA_BACKEND_DIR = os.path.join(COBOT_ROOT, 'err-backend-gitter')
+    BOT_EXTRA_BACKEND_DIR = os.path.join(BOT_ROOT, 'err-backend-gitter')
 else:
     BOT_EXTRA_BACKEND_DIR = None
 
@@ -46,10 +54,10 @@ if BOT_EXTRA_BACKEND_DIR:
 
 HIDE_RESTRICTED_COMMANDS = True
 
-BOT_DATA_DIR = os.path.join(COBOT_ROOT, 'data')
-BOT_EXTRA_PLUGIN_DIR = COBOT_ROOT
+BOT_DATA_DIR = os.path.join(BOT_ROOT, 'data')
+BOT_EXTRA_PLUGIN_DIR = BOT_ROOT
 
-BOT_LOG_FILE = os.path.join(COBOT_ROOT, 'errbot.log')
+BOT_LOG_FILE = os.path.join(BOT_ROOT, 'errbot.log')
 BOT_LOG_LEVEL = logging.DEBUG
 
 BOT_PREFIX = os.environ.get('BOT_PREFIX', 'corobo ')

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -17,7 +17,7 @@ class Utils(BotPlugin):
     @botcmd(admin_only=True)
     def sync(self, msg, arg):
         """Sync the repository from github."""  # Ignore QuotesBear
-        repo = git.Repo(self.bot_config.COBOT_ROOT)
+        repo = git.Repo(self.bot_config.BOT_ROOT)
         try:
             repo.remote('origin').pull('--rebase')
             yield 'Sync\'d successfully! :tada:'
@@ -27,14 +27,14 @@ class Utils(BotPlugin):
     @botcmd
     def get_head(self, msg, arg):
         """Yields the head commit."""  # Ignore QuotesBear
-        repo = git.Repo(self.bot_config.COBOT_ROOT)
+        repo = git.Repo(self.bot_config.BOT_ROOT)
         head = repo.commit('HEAD')
         yield '`{}`: {}'.format(head.hexsha, head.message)
 
     @botcmd(admin_only=True)
     def install_requirements(self, msg, arg):
         """Installs requirements"""  # Ignore QuotesBear
-        os.chdir(self.bot_config.COBOT_ROOT)
+        os.chdir(self.bot_config.BOT_ROOT)
         ran = run('pip install -r requirements.txt')
         yield 'installing requirements...'
         yield ran.stdout.read().decode('utf-8')


### PR DESCRIPTION
Add backward compatibilty for COBOT_ROOT with a
warning.

Closes https://github.com/coala/corobo/issues/371

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
