### PR TITLE
labhub.py: Block gci issue assignment

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -350,6 +350,14 @@ class LabHub(BotPlugin):
                 else:
                     return True
 
+            @register_check
+            def block_gci_issue_assignment(user, iss):
+                """
+                True if the issue is not labelled with 'initiatives/gci'.
+                False if the issue has been labelled with 'initiatives/gci'.
+                """
+                return 'initiatives/gci' not in iss.labels
+
         def eligible(user, iss):
             for chk in checks:
                 if not chk(user, iss):

--- a/plugins/templates/labhub/errors/not-eligible.jinja2.md
+++ b/plugins/templates/labhub/errors/not-eligible.jinja2.md
@@ -2,3 +2,4 @@
 - A newcomer cannot be assigned to an issue with a difficulty level higher than newcomer or low difficulty.
 - A newcomer cannot be assigned to unlabelled issues.
 - A newcomer cannot be assigned to more than one difficulty/newcomer issue.
+- corobo cannot assign issues labelled with 'initiatives/gci' tag.

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -233,6 +233,27 @@ class TestLabHub(unittest.TestCase):
 
         testbot.assertCommand(cmd.format('coala', 'a', '23'),
                               'You\'ve been assigned to the issue')
+        
+        # no assignee, newcomer, initiatives/gci
+        mock_maint_team.is_member.return_value = False
+        mock_dev_team.is_member.return_value = False
+        mock_issue.labels = 'initiatives/gci',
+        mock_issue.assignees = tuple()
+        testbot.assertCommand(cmd.format('coala', 'a', '23'),
+                              'You are not eligible to be assigned'
+                              ' to this issue')
+        testbot.pop_message()
+
+        # no assignee, developer, initiatives/gci
+        mock_maint_team.is_member.return_value = False
+        mock_dev_team.is_member.return_value = True
+        mock_issue.labels = 'initiatives/gci',
+        mock_issue.assignees = tuple()
+        testbot.assertCommand(cmd.format('coala', 'a', '23'),
+                              'You are not eligible to be assigned'
+                              ' to this issue')
+        testbot.pop_message()
+        mock_dev_team.is_member.return_value = False
 
         # no assignee, newcomer, difficulty/low
         mock_issue.labels = PropertyMock()


### PR DESCRIPTION
Block assignment of issues labeled as
'initiatives/gci'.

Closes https://github.com/coala/corobo/issues/501

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
