### PR TITLE
Deprecate COBOT_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Read more about what `corobo` could do for you
 ## Environment Variables
 
 1. `COBOT_ROOT` - absolute path of the project root.
-2. `COBOT_PREFIX` - prefix to use for issuing bot commands.
+2. `BOT_PREFIX` - prefix to use for issuing bot commands.
 3. `BOT_ADMINS` - Admins of the errbot instance.
 4. `ROOMS` - Space separated list of rooms to join on startup. e.g.
    `ROOMS="coala/coala coala/coala/corobo"`

--- a/config.py
+++ b/config.py
@@ -52,10 +52,16 @@ BOT_EXTRA_PLUGIN_DIR = COBOT_ROOT
 BOT_LOG_FILE = os.path.join(COBOT_ROOT, 'errbot.log')
 BOT_LOG_LEVEL = logging.DEBUG
 
-BOT_PREFIX = os.environ.get('COBOT_PREFIX', 'corobo ')
+BOT_PREFIX = os.environ.get('BOT_PREFIX', 'corobo ')
+
+if 'COBOT_PREFIX' in os.environ:
+    BOT_PREFIX = os.environ['COBOT_PREFIX']
+    logging.warning(
+        'Deprecation warning: environment variable COBOT_PREFIX is replaced '
+        'by BOT_PREFIX.')
 
 # Also listen to cobot, if the bot being ran is corobo
-if not os.environ.get('COBOT_PREFIX'):
+if not os.environ.get('BOT_PREFIX'):
     BOT_ALT_PREFIXES = ('cobot ', )
 
 BOT_DEPRECATED_PREFIXES = os.environ.get(


### PR DESCRIPTION
Deprecate the use of the environment variable COBOT_PREFIX and
replace it with BOT_PREFIX, issue a warning if COBOT_PREFIX is
still being used.

Closes https://github.com/coala/corobo/issues/370

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
