### PR TITLE
Closes #307

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -73,7 +73,7 @@ class LabHub(BotPlugin):
 
     # Ignore LineLengthBear, PycodestyleBear
     @re_botcmd(pattern=r'^(?:(?:welcome)|(?:inv)|(?:invite))\s+(?:(?:@?([\w-]+)(?:\s*(?:to)\s+(\w+))?)|(me))$',
-               re_cmd_name_help='invite [to team]')
+               re_cmd_name_help='invite ([@]<username> [to <team>]|me)')
     def invite_cmd(self, msg, match):
         """
         Invite given user to given team. By default it invites to


### PR DESCRIPTION
labhub: Show 'invite me' as help in `invite_cmd` 

The help command will now show how the invite command can work in two formats, displayed as a single string `'invite ([@]<username> [to <team>]|me)'`. Added a test to verify this as well.

Closes #307 
# Reviewers Checklist

- [ ] Appropriate logging is done.
- [x] Appropriate error responses.
- [ ] Handle every possible exception.
- [x] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [x] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
