### PR TITLE
Closes #512

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -72,7 +72,7 @@ class LabHub(BotPlugin):
         self._teams = new
 
     # Ignore LineLengthBear, PycodestyleBear
-    @re_botcmd(pattern=r'^(?:(?:welcome)|(?:inv)|(?:invite))\s+(?:(?:@?([\w-]+)(?:\s*(?:to)\s+(\w+))?)|(me))$',
+    @re_botcmd(pattern=r'^(?:(?:welcome)|(?:inv)|(?:invite))\s+(?:(?:@?([\w-]+)(?:\s+(?:to)\s+(\w+))?)|(me))$',
                re_cmd_name_help='invite ([@]<username> [to <team>]|me)')
     def invite_cmd(self, msg, match):
         """

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -59,6 +59,8 @@ class TestLabHub(unittest.TestCase):
         testbot.assertCommand('!invite meet to developers',
                                    ':poop:')
 
+        testbot.assertCommand('!invite meetto newcomers',
+                                   'Command "invite" / "invite meetto" not found.')
     def test_hello_world_callback(self):
         teams = {
             'coala newcomers': self.mock_team,


### PR DESCRIPTION
labhub: Change regex pattern for 'invite_cmd'

The original file had regex for `\s*` which matches 0 or more whitespaces which led to matches such as *'invite @userto developers'* since it matched 0 whitespaces between *'@user'* and *'to'*. With `\s+` it matches 1 or more whitespace and hence *'invite @userto developers'* will not be matched. Added a test to verify this as well.

Fixes https://github.com/coala/corobo/issues/512
# Reviewers Checklist
- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
