### PR TITLE
Fix semaphore builds

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -31,7 +31,7 @@ class LabHub(BotPlugin):
             self.log.error('Cannot create github object, please check GH_TOKEN')
         else:
             self.GH3_ORG = gh.organization(self.GH_ORG_NAME)
-            for team in self.GH3_ORG.iter_teams():
+            for team in self.GH3_ORG.teams():
                 teams[team.name] = team
 
         self._teams = teams

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyopenssl<17.5
 git+https://github.com/errbotio/errbot@c2639879d4c298933cdf406193de5a5e626db12b
 wolframalpha
-github3.py
+github3.py~=1.0.0
 IGitt==0.4.1.dev20171129151739
 gitpython
 vcrpy

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -32,7 +32,7 @@ class TestLabHub(unittest.TestCase):
 
         plugins.labhub.github3.login.return_value = self.mock_gh
         self.mock_gh.organization.return_value = self.mock_org
-        self.mock_org.iter_teams.return_value = [self.mock_team]
+        self.mock_org.teams.return_value = [self.mock_team]
         plugins.labhub.github3.organization.return_value = self.mock_org
 
     def test_invite_cmd(self):


### PR DESCRIPTION
Update `org.iter_teams` to `org.teams` as per
the new release notes of github3.py v1.0.0

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
