### PR TITLE
[GSoC '18] labhub: assign_cmd newcomer's issue tracker

### DIFF
--- a/plugins/templates/labhub/errors/not-eligible.jinja2.md
+++ b/plugins/templates/labhub/errors/not-eligible.jinja2.md
@@ -1,3 +1,4 @@
 - You must be a member of the {{ organization }} org to be assigned an issue. If you are not a member yet, just type Hello World and corobo will invite you.
 - A newcomer cannot be assigned to an issue with a difficulty level higher than newcomer or low difficulty.
 - A newcomer cannot be assigned to unlabelled issues.
+- A newcomer cannot be assigned to more than one difficulty/newcomer issue.


### PR DESCRIPTION
Newcomers won't be able to get assigned to
more that one newcomer issue.

Closes https://github.com/coala/corobo/issues/540