### PR TITLE
labhub.py: Remove unused variable

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -61,7 +61,6 @@ class LabHub(BotPlugin):
         else:
             self.REPOS.update(self.gl_repos)
 
-        self.invited_users = set()
         self.hello_world_users = set()
 
     @property


### PR DESCRIPTION
Removed variable invited_users from class LabHub as it is not used
anywhere.

Closes https://github.com/coala/corobo/issues/557
