### PR TITLE
labhub_test: Increase timeout to fix random CI failures

### DIFF
--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -400,7 +400,7 @@ class TestLabHub(unittest.TestCase):
             labhub.gh_repos['coala'].search_mrs.return_value = []
             testbot.assertCommand('!pr stats 5hours',
                                   '0 PRs opened in last 5 hours\n'
-                                  'The community is dead')
+                                  'The community is dead', timeout=100)
 
             labhub.gh_repos['coala'].search_mrs.return_value = [
                 1, 2, 3, 4, 5,
@@ -408,4 +408,4 @@ class TestLabHub(unittest.TestCase):
             ]
             testbot.assertCommand('!pr stats 3hours',
                                   '10 PRs opened in last 3 hours\n'
-                                  'The community is on fire')
+                                  'The community is on fire', timeout=100)


### PR DESCRIPTION
Default 5 sec timeout was causing unexpected random CI
failure.

Closes https://github.com/coala/corobo/issues/564

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
