### PR TITLE
LabHub: Remove redundant teams list

### DIFF
--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -111,6 +111,8 @@ class TestLabHub(unittest.TestCase):
     def test_hello_world_callback(self):
         teams = {
             'coala newcomers': self.mock_team,
+            'coala developers': self.mock_team,
+            'coala maintainers': self.mock_team,
         }
 
         testbot = TestBot(extra_plugin_dir='plugins', loglevel=logging.ERROR)


### PR DESCRIPTION
Redefine excessive usage for the list
of teams.

Closes https://github.com/coala/corobo/issues/575