### PR TITLE
LabHub: Use activate and configuration templates

### DIFF
--- a/config.py
+++ b/config.py
@@ -111,3 +111,12 @@ ACCESS_CONTROLS = {'render test': {
     'LabHub:*': {'allowprivate': False}}
 
 AUTOINSTALL_DEPS = True
+
+DEFAULT_CONFIG = {
+    'LabHub': {
+        'GH_TOKEN': os.environ.get('GH_TOKEN'),
+        'GL_TOKEN': os.environ.get('GL_TOKEN'),
+        'GH_ORG_NAME': os.environ.get('GH_ORG_NAME', 'coala'),
+        'GL_ORG_NAME': os.environ.get('GL_ORG_NAME', 'coala'),
+    },
+}

--- a/plugins/constants.py
+++ b/plugins/constants.py
@@ -1,10 +1,6 @@
-import os
 
 API_DOCS = 'http://api.coala.io/en/latest'
 USER_DOCS = 'http://docs.coala.io/en/latest'
-
-GH_ORG_NAME = os.environ.get('GH_ORG_NAME', 'coala')
-GL_ORG_NAME = os.environ.get('GL_ORG_NAME', 'coala')
 
 MAX_MSG_LEN = 1000
 MAX_LINES = 20

--- a/tests/answer_test.py
+++ b/tests/answer_test.py
@@ -1,22 +1,15 @@
 import os
-import logging
-
-from errbot.backends.test import FullStackTest
 import vcr
 import requests_mock
 
 import plugins.answer
+from tests.isolated_testcase import IsolatedTestCase
 
 
-class TestAnswer(FullStackTest):
+class TestAnswer(IsolatedTestCase):
 
-    def setUp(self,
-              extra_plugin_dir=None,
-              extra_test_file=None,
-              loglevel=logging.DEBUG,
-              extra_config=None):
-        super().setUp(extra_plugin_dir='plugins',
-                      loglevel=logging.ERROR)
+    def setUp(self):
+        super().setUp()
         # Ignore InvalidLinkBear
         self.answer_end_point = 'http://0.0.0.0:8000'
         os.environ['ANSWER_END'] = self.answer_end_point

--- a/tests/coala_lowercase_c_test.py
+++ b/tests/coala_lowercase_c_test.py
@@ -1,13 +1,12 @@
-pytest_plugins = ['errbot.backends.test']
-
-extra_plugin_dir = 'plugins'
+from tests.isolated_testcase import IsolatedTestCase
 
 
-def test_coala_lowercase(testbot):
-    testbot.assertCommand('what is Coala?',
-                          'coala is always written with a lower case c')
+class CoalaLowercaseTest(IsolatedTestCase):
 
+    def test_coala_lowercase(self):
+        self.assertCommand('what is Coala?',
+                           'coala is always written with a lower case c')
 
-def test_cep(testbot):
-    testbot.assertCommand('what is a CEP?',
-                          'cEP is always written with a lower case c')
+    def test_cep(self):
+        self.assertCommand('what is a CEP?',
+                           'cEP is always written with a lower case c')

--- a/tests/coatils_test.py
+++ b/tests/coatils_test.py
@@ -1,21 +1,12 @@
-import logging
 import queue
 
-from errbot.backends.test import FullStackTest
+from tests.isolated_testcase import IsolatedTestCase
 import vcr
 
 from plugins.coatils import Coatils
 
 
-class TestCoatils(FullStackTest):
-
-    def setUp(self,
-              extra_plugin_dir=None,
-              extra_test_file=None,
-              loglevel=logging.DEBUG,
-              extra_config=None):
-        super().setUp(extra_plugin_dir='plugins',
-                      loglevel=logging.ERROR)
+class TestCoatils(IsolatedTestCase):
 
     @vcr.use_cassette('tests/cassettes/coatils_total_bears.yaml')
     def test_total_bears(self):

--- a/tests/corobo_test_case.py
+++ b/tests/corobo_test_case.py
@@ -28,10 +28,14 @@ class CoroboTestCase(FullStackTest):
             self.plug_files[klass.__name__] = plug_info
             add_plugin_templates_path(plug_info)
 
-    def load_plugin(self, plugin_name: str, mock_dict=False):
+    def load_plugin(self,
+                    plugin_name: str,
+                    mock_dict=False,
+                    plugin_config=None):
         """Load plugin manually"""
         klass = self.klasses[plugin_name]
         plugin = klass(self.bot, plugin_name)
+        plugin.configure(plugin_config)
         self.plugins[plugin_name] = plugin
         self.bot.plugin_manager.plugins[plugin_name] = plugin
         plug_file = self.plug_files[plugin_name]

--- a/tests/deprecate_bot_prefixes_test.py
+++ b/tests/deprecate_bot_prefixes_test.py
@@ -1,8 +1,9 @@
-pytest_plugins = ['errbot.backends.test']
-extra_plugin_dir = 'plugins'
+from tests.isolated_testcase import IsolatedTestCase
 
 
-def test_deprecated_prefixes_other(testbot):
-    testbot.bot_config.BOT_DEPRECATED_PREFIXES = ('oldbot', 'deprecatedbot')
-    testbot.assertCommand('oldbot just a test', 'has been deprecated')
-    testbot.assertCommand('deprecatedbot just a test', 'has been deprecated')
+class DeprecateBotPrefixesTest(IsolatedTestCase):
+
+    def test_deprecated_prefixes_other(self):
+        self.bot_config.BOT_DEPRECATED_PREFIXES = ('oldbot', 'deprecatedbot')
+        self.assertCommand('oldbot just a test', 'has been deprecated')
+        self.assertCommand('deprecatedbot just a test', 'has been deprecated')

--- a/tests/explain_test.py
+++ b/tests/explain_test.py
@@ -1,20 +1,20 @@
 import errbot.rendering
 
+from tests.isolated_testcase import IsolatedTestCase
 from plugins.explain import Explain
 
-pytest_plugins = ['errbot.backends.test']
-
-extra_plugin_dir = 'plugins'
 
 text = errbot.rendering.text()
 
 
-def test_explain(testbot):
-    testbot.assertCommand("!explain REView", 'For a good review,')
-    testbot.assertCommand("!explain gOOgle", 'use google')
-    testbot.assertCommand("!explain not_found",
-                          text.convert(Explain.ERROR_MSG))
-    testbot.assertCommand("!explain review to @meet",
-                          '@meet')
-    testbot.assertCommand("!please explain review",
-                          "Command \"please\" / \"please explain\" not found.")
+class ExplainTest(IsolatedTestCase):
+
+    def test_explain(self):
+        self.assertCommand('!explain REView', 'For a good review,')
+        self.assertCommand('!explain gOOgle', 'use google')
+        self.assertCommand('!explain not_found',
+                           text.convert(Explain.ERROR_MSG))
+        self.assertCommand('!explain review to @meet',
+                           '@meet')
+        self.assertCommand('!please explain review',
+                           'Command \"please\" / \"please explain\" not found.')

--- a/tests/ghetto_test.py
+++ b/tests/ghetto_test.py
@@ -1,15 +1,15 @@
 import requests_mock
 import vcr
 
-pytest_plugins = ['errbot.backends.test']
-
-extra_plugin_dir = 'plugins'
+from tests.isolated_testcase import IsolatedTestCase
 
 
-@vcr.use_cassette('tests/cassettes/ghetto.yaml')
-def test_ghetto(testbot):
-    testbot.assertCommand("!ghetto hi, whats up?", "hi, wassup?")
-    with requests_mock.Mocker() as m:
-        m.register_uri('POST', 'http://www.gizoogle.net/textilizer.php',
-                       text='test text which will not match with the regex')
-        testbot.assertCommand("!ghetto ...", "Shiznit happens!")
+class GhettoTest(IsolatedTestCase):
+
+    @vcr.use_cassette('tests/cassettes/ghetto.yaml')
+    def test_ghetto(self):
+        self.assertCommand('!ghetto hi, whats up?', 'hi, wassup?')
+        with requests_mock.Mocker() as m:
+            m.register_uri('POST', 'http://www.gizoogle.net/textilizer.php',
+                           text='test text which will not match with the regex')
+            self.assertCommand('!ghetto ...', 'Shiznit happens!')

--- a/tests/isolated_testcase.py
+++ b/tests/isolated_testcase.py
@@ -1,0 +1,24 @@
+import logging
+import os
+
+from errbot.backends.test import FullStackTest
+from pathlib import Path
+
+
+class IsolatedTestCase(FullStackTest):
+
+    file_path = Path(__file__).parent / '..' / 'plugins' / 'labhub.plug'
+    renamed_file_path = Path(__file__).parent / '..' / 'plugins' / 'hidden'
+
+    @classmethod
+    def setUpClass(cls, extra_config=None):
+        os.rename(cls.file_path, cls.renamed_file_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.rename(cls.renamed_file_path, cls.file_path)
+
+    def setUp(self, extra_config=None):
+        super().setUp(extra_plugin_dir='plugins',
+                      loglevel=logging.ERROR,
+                      extra_config=extra_config)

--- a/tests/lmgtfy_test.py
+++ b/tests/lmgtfy_test.py
@@ -1,13 +1,12 @@
 import errbot.rendering
 
 from plugins.lmgtfy import Lmgtfy
-
-pytest_plugins = ['errbot.backends.test']
-
-extra_plugin_dir = 'plugins'
+from tests.isolated_testcase import IsolatedTestCase
 
 text = errbot.rendering.text()
 
 
-def test_lmgtfy(testbot):
-    testbot.assertCommand("!lmgtfy py c", "https://www.lmgtfy.com/?q=py c")
+class LmgtfyTest(IsolatedTestCase):
+
+    def test_lmgtfy(self):
+        self.assertCommand('!lmgtfy py c', 'https://www.lmgtfy.com/?q=py c')

--- a/tests/nevermind_test.py
+++ b/tests/nevermind_test.py
@@ -1,15 +1,15 @@
-pytest_plugins = ['errbot.backends.test']
-
-extra_plugin_dir = ['plugins']
+from tests.isolated_testcase import IsolatedTestCase
 
 
-def test_nevermind(testbot):
-    testbot.assertCommand("!nevermind", "I'm sorry :(")
-    testbot.assertCommand("!nm", "I'm sorry :(")
-    testbot.assertCommand("!nEverMINd", "I'm sorry :(")
-    testbot.assertCommand("!nM", "I'm sorry :(")
-    testbot.assertCommand("!nmxyz", 'Command "nmxyz" not found.')
-    testbot.assertCommand("!hey nM", 'Command "hey" / "hey nM" not found.')
-    testbot.assertCommand("!nevermindxyz", 'Command "nevermindxyz" not found.')
-    testbot.assertCommand(
-        "!hey nEverMINd", 'Command "hey" / "hey nEverMINd" not found.')
+class NevermindTest(IsolatedTestCase):
+
+    def test_nevermind(self):
+        self.assertCommand('!nevermind', 'I\'m sorry :(')
+        self.assertCommand('!nm', 'I\'m sorry :(')
+        self.assertCommand('!nEverMINd', 'I\'m sorry :(')
+        self.assertCommand('!nM', 'I\'m sorry :(')
+        self.assertCommand('!nmxyz', 'Command "nmxyz" not found.')
+        self.assertCommand('!hey nM', 'Command "hey" / "hey nM" not found.')
+        self.assertCommand('!nevermindxyz', 'Command "nevermindxyz" not found.')
+        self.assertCommand('!hey nEverMINd',
+                           'Command "hey" / "hey nEverMINd" not found.')

--- a/tests/pitchfork_test.py
+++ b/tests/pitchfork_test.py
@@ -1,9 +1,10 @@
-pytest_plugins = ['errbot.backends.test']
-extra_plugin_dir = 'plugins'
+from tests.isolated_testcase import IsolatedTestCase
 
 
-def test(testbot):
-    testbot.assertCommand('!pitchfork @meet', 'being pitchforked')
-    testbot.assertCommand('!pitchfork @meet down to hell', 'being pitchforked')
-    testbot.assertCommand('!pitchfork meet to hell', 'being pitchforked')
-    testbot.assertCommand('!pitchfork', 'Usage')
+class PitchForkTest(IsolatedTestCase):
+
+    def test(self):
+        self.assertCommand('!pitchfork @meet', 'being pitchforked')
+        self.assertCommand('!pitchfork @meet down to hell', 'being pitchforked')
+        self.assertCommand('!pitchfork meet to hell', 'being pitchforked')
+        self.assertCommand('!pitchfork', 'Usage')

--- a/tests/searchdocs_test.py
+++ b/tests/searchdocs_test.py
@@ -1,14 +1,14 @@
-pytest_plugins = ['errbot.backends.test']
-
-extra_plugin_dir = 'plugins'
+from tests.isolated_testcase import IsolatedTestCase
 
 
-def test_search_cmd(testbot):
-    testbot.assertCommand(
-        '!search api this is search string',
-        'http://api.coala.io/en/latest/search.html?q=this+is+search+string')
-    testbot.assertCommand(
-        '!search user this is search string',
-        'http://docs.coala.io/en/latest/search.html?q=this+is+search+string')
-    testbot.assertCommand('!search not matching',
-                          'Invalid syntax')
+class SearchDocsTest(IsolatedTestCase):
+
+    def test_search_cmd(self):
+        self.assertCommand(
+            '!search api search string',
+            'http://api.coala.io/en/latest/search.html?q=search+string')
+        self.assertCommand(
+            '!search user search string',
+            'http://docs.coala.io/en/latest/search.html?q=search+string')
+        self.assertCommand('!search not matching',
+                           'Invalid syntax')

--- a/tests/ship_it_test.py
+++ b/tests/ship_it_test.py
@@ -1,10 +1,10 @@
 import errbot.rendering
 
-pytest_plugins = ['errbot.backends.test']
-
-extra_plugin_dir = 'plugins'
+from tests.isolated_testcase import IsolatedTestCase
 
 
-def test_ship_it(testbot):
-    text = errbot.rendering.text()
-    testbot.assertCommand("!shipit", text.convert("![ship it!]()"))
+class ShipItTest(IsolatedTestCase):
+
+    def test_ship_it(self):
+        text = errbot.rendering.text()
+        self.assertCommand('!shipit', text.convert('![ship it!]()'))

--- a/tests/spam_test.py
+++ b/tests/spam_test.py
@@ -1,19 +1,13 @@
-import logging
 import queue
-import unittest
 
-from errbot.backends.test import TestBot
+from tests.isolated_testcase import IsolatedTestCase
 
 
-class TestSpam(unittest.TestCase):
+class TestSpam(IsolatedTestCase):
 
     def setUp(self):
-        self.testbot = TestBot(extra_plugin_dir='plugins',
-                               loglevel=logging.ERROR)
-        self.testbot.start()
-
-    def tearDown(self):
-        self.testbot.stop()
+        super().setUp()
+        self.testbot = self
 
     def test_spam_callback(self):
         self.testbot.assertCommand('c'*1001, 'you\'re spamming')
@@ -32,7 +26,7 @@ class TestSpam(unittest.TestCase):
                                    '{\'MAX_LINES\': 20, \'MAX_MSG_LEN\': 200}')
 
 
-class TestSpamExtraConfig(unittest.TestCase):
+class TestSpamExtraConfig(IsolatedTestCase):
 
     def setUp(self):
         extra_config = {
@@ -43,13 +37,8 @@ class TestSpamExtraConfig(unittest.TestCase):
                 }
             }
         }
-        self.testbot = TestBot(extra_plugin_dir='plugins',
-                               loglevel=logging.ERROR,
-                               extra_config=extra_config)
-        self.testbot.start()
-
-    def tearDown(self):
-        self.testbot.stop()
+        super().setUp(extra_config=extra_config)
+        self.testbot = self
 
     def test_spam_extra_config_callback(self):
         self.testbot.assertCommand('c'*501, 'you\'re spamming')

--- a/tests/the_rules_test.py
+++ b/tests/the_rules_test.py
@@ -1,11 +1,10 @@
 from plugins.the_rules import The_rules
-
-pytest_plugins = ['errbot.backends.test']
-
-extra_plugin_dir = 'plugins'
+from tests.isolated_testcase import IsolatedTestCase
 
 
-def test_the_rules(testbot):
-    testbot.assertCommand('!the rules', 'A robot may not harm humanity')
-    testbot.assertCommand('!the  rules', 'A robot may not injure a human')
-    testbot.assertCommand('!THE RUles', 'A robot must obey any orders')
+class TheRulesTest(IsolatedTestCase):
+
+    def test_the_rules(self):
+        self.assertCommand('!the rules', 'A robot may not harm humanity')
+        self.assertCommand('!the  rules', 'A robot may not injure a human')
+        self.assertCommand('!THE RUles', 'A robot must obey any orders')

--- a/tests/wolfram_alpha_test.py
+++ b/tests/wolfram_alpha_test.py
@@ -1,23 +1,13 @@
-import logging
-
 import vcr
-from errbot.backends.test import FullStackTest
 
 from plugins.wolfram_alpha import WolframAlpha
+from tests.isolated_testcase import IsolatedTestCase
 
 my_vcr = vcr.VCR(match_on=['method', 'scheme', 'host', 'port', 'path'],
                  filter_query_parameters=['appid'])
 
 
-class WolframAlphaTest(FullStackTest):
-
-    def setUp(self,
-              extra_plugin_dir=None,
-              extra_test_file=None,
-              loglevel=logging.DEBUG,
-              extra_config=None):
-        super().setUp(extra_plugin_dir='plugins',
-                      loglevel=logging.ERROR)
+class WolframAlphaTest(IsolatedTestCase):
 
     @my_vcr.use_cassette('tests/cassettes/wa.yaml')
     def test_wa(self):


### PR DESCRIPTION
`__init__` is executed at load time and
and any issue in the plugin will lead
to it not showing up.
LifeCycle: `__init__`->configured->enable

Adapts to the `DefaultConfigMixin` and
migrated to using configuration templates.

Closes https://github.com/coala/corobo/issues/554
Closes https://github.com/coala/corobo/issues/382