### PR TITLE
DefaultConfigMixin: Modify implementation

### DIFF
--- a/config.py
+++ b/config.py
@@ -119,4 +119,7 @@ DEFAULT_CONFIG = {
         'GH_ORG_NAME': os.environ.get('GH_ORG_NAME', 'coala'),
         'GL_ORG_NAME': os.environ.get('GL_ORG_NAME', 'coala'),
     },
+    'WolframAlpha': {
+        'WA_TOKEN': os.environ.get('WA_TOKEN'),
+    },
 }

--- a/config.py
+++ b/config.py
@@ -113,6 +113,9 @@ ACCESS_CONTROLS = {'render test': {
 AUTOINSTALL_DEPS = True
 
 DEFAULT_CONFIG = {
+    'answer': {
+        'ANSWER_END': os.environ.get('ANSWER_END'),
+    },
     'LabHub': {
         'GH_TOKEN': os.environ.get('GH_TOKEN'),
         'GL_TOKEN': os.environ.get('GL_TOKEN'),

--- a/plugins/answer.py
+++ b/plugins/answer.py
@@ -1,13 +1,16 @@
 import json
-import os
 from urllib.parse import quote_plus, urljoin
 
 from errbot import BotPlugin, botcmd
+from utils.mixin import DefaultConfigMixin
 import requests
 
 
-class Answer(BotPlugin):
+class Answer(DefaultConfigMixin, BotPlugin):
 
+    CONFIG_TEMPLATE = {
+        'ANSWER_END': None,
+    }
     # Ignore LineLengthBear, PyCodestyleBear
     SURVEY_LINK = 'https://docs.google.com/forms/d/e/1FAIpQLSeD8lqMWAwJx0Mewlpc5Sbeo3MH5Yi9fSfXA6jnk07-aIURSA/viewform?usp=pp_url&entry.1236347280={question}&entry.1734934116={response}&entry.75323266={message_link}'
     MESSAGE_LINK = 'https://gitter.im/{uri}?at={idd}'
@@ -26,7 +29,7 @@ class Answer(BotPlugin):
     @botcmd
     def answer(self, msg, arg):
         try:
-            answers = requests.get(urljoin(os.environ['ANSWER_END'], 'answer'),
+            answers = requests.get(urljoin(self.config['ANSWER_END'], 'answer'),
                                    params={'question': arg}).json()
         except json.JSONDecodeError:
             self.log.exception('something went wrong while fetching answer for'

--- a/plugins/wolfram_alpha.plug
+++ b/plugins/wolfram_alpha.plug
@@ -1,5 +1,5 @@
 [Core]
-name = wolfram alpha
+name = WolframAlpha
 module = wolfram_alpha
 
 [Documentation]

--- a/plugins/wolfram_alpha.py
+++ b/plugins/wolfram_alpha.py
@@ -1,18 +1,21 @@
-import os
-
 import wolframalpha
 
 from errbot import BotPlugin, botcmd
+from utils.mixin import DefaultConfigMixin
 
 
-class WolframAlpha(BotPlugin):
+class WolframAlpha(DefaultConfigMixin, BotPlugin):
     """
     Query the Computational Knowledge Engine
     """
 
+    CONFIG_TEMPLATE = {
+        'WA_TOKEN': None,
+    }
+
     def activate(self):
         super().activate()
-        self.client = wolframalpha.Client(os.environ.get('WA_TOKEN'))
+        self.client = wolframalpha.Client(self.config['WA_TOKEN'])
 
     @botcmd
     def wa(self, msg, arg):

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,5 @@ exclude_lines =
   pragma ${OS_NAME}: no cover
   pragma Python [0-9.,]*${PYTHON_VERSION}[0-9.,]*: no cover
   def message_link
-  def get_configuration_template
 
 [coverage:force_end_of_section]

--- a/tests/spam_test.py
+++ b/tests/spam_test.py
@@ -33,7 +33,6 @@ class TestSpamExtraConfig(IsolatedTestCase):
             'DEFAULT_CONFIG': {
                 'SpammingAlert': {
                     'MAX_MSG_LEN': 500,
-                    'MAX_LINES': 5,
                 }
             }
         }
@@ -42,13 +41,15 @@ class TestSpamExtraConfig(IsolatedTestCase):
 
     def test_spam_extra_config_callback(self):
         self.testbot.assertCommand('c'*501, 'you\'re spamming')
-        self.testbot.assertCommand('\n'*6, 'you\'re spamming')
+        self.testbot.assertCommand('\n\n'*11, 'you\'re spamming')
         # Since the message is not a spam, testbot will timeout
         # waiting for a response
         with self.assertRaises(queue.Empty):
             self.testbot.assertCommand('Not a spam', 'you\'re spamming')
 
     def test_spam_extra_config_configuration(self):
+        self.testbot.assertCommand('!plugin config SpammingAlert',
+                                   '{\'MAX_LINES\': 20, \'MAX_MSG_LEN\': 500}')
         self.testbot.assertCommand('!plugin config SpammingAlert '
                                    '{\'MAX_LINES\': 10}',
                                    'configuration done')

--- a/tests/wolfram_alpha_test.py
+++ b/tests/wolfram_alpha_test.py
@@ -9,6 +9,9 @@ my_vcr = vcr.VCR(match_on=['method', 'scheme', 'host', 'port', 'path'],
 
 class WolframAlphaTest(IsolatedTestCase):
 
+    def setUp(self):
+        super().setUp()
+
     @my_vcr.use_cassette('tests/cassettes/wa.yaml')
     def test_wa(self):
         self.push_message('!wa 2^6')
@@ -16,5 +19,7 @@ class WolframAlphaTest(IsolatedTestCase):
         with self.assertLogs() as cm:
             self.assertCommand('!wa this is a sentence',
                                'Dunno')
-        self.assertIn('INFO:errbot.plugins.wolfram alpha:KeyError triggered on '
+        self.assertIn('INFO:errbot.plugins.WolframAlpha:KeyError triggered on '
                       'retrieving pods.', cm.output)
+        self.assertCommand('!plugin config WolframAlpha',
+                           '{\'WA_TOKEN\': None}')

--- a/utils/mixin.py
+++ b/utils/mixin.py
@@ -10,31 +10,29 @@ class DefaultConfigMixin():
 
     def __init__(self, bot, name=None):
         super().__init__(bot, name=name)
-        default_config = self._default_config
-        if default_config and not hasattr(self, 'config'):
-            self.configure(default_config)
+        if not hasattr(self, 'CONFIG_TEMPLATE'):  # pragma: no cover
+            self.log.error('CONFIG_TEMPLATE for plugin {} is missing.'
+                           .format(self.name))
 
     def get_configuration_template(self):
         default_config = self._default_config
+        config_template = self.CONFIG_TEMPLATE
+
         if default_config:
-            return default_config
-        elif self.CONFIG_TEMPLATE:
-            return self.CONFIG_TEMPLATE
-        else:  # pragma: no cover
-            return
+            config = dict(chain(config_template.items(),
+                                default_config.items()))
+        else:
+            config = config_template
+
+        return config
 
     def configure(self, configuration):
-        default_config = self._default_config
-        if configuration and default_config:
-            config = dict(chain(
-                default_config.items(),
-                configuration.items()))
-        elif configuration:
-            config = dict(chain(self.CONFIG_TEMPLATE.items(),
-                          configuration.items()))
-        elif default_config:
-            config = default_config
+        config_template = self.get_configuration_template()
+
+        if configuration is not None and configuration != {}:
+            config = dict(chain(config_template.items(),
+                                configuration.items()))
         else:
-            config = self.CONFIG_TEMPLATE
+            config = config_template
 
         self.config = config


### PR DESCRIPTION
Store the default values in `CONFIG_TEMPLATE` and
then allow a subset of those config variables
overridden in the config.py's `DEFAULT_CONFIG`.

Closes https://github.com/coala/corobo/issues/596