### PR TITLE
GitStats: Remove LabHub inheritance

### DIFF
--- a/plugins/git_stats.plug
+++ b/plugins/git_stats.plug
@@ -1,6 +1,7 @@
 [Core]
 name = GitStats
 module = git_stats
+DependsOn = LabHub
 
 [Documentation]
 description = GitHub and GitLab statistics

--- a/plugins/git_stats.py
+++ b/plugins/git_stats.py
@@ -2,12 +2,10 @@ import datetime
 import re
 from shutil import rmtree
 
-from errbot import re_botcmd
-
-from plugins.labhub import LabHub
+from errbot import BotPlugin, re_botcmd
 
 
-class GitStats(LabHub):
+class GitStats(BotPlugin):
     """GitHub and GitLab statistics"""  # Ignore QuotesBear
 
     PR_LABELS = ('process/approved',
@@ -15,8 +13,9 @@ class GitStats(LabHub):
                  'process/pending-review'
                  )
 
-    def __init__(self, bot, name=None):
-        super().__init__(bot, name)
+    def activate(self):
+        super().activate()
+        self.REPOS = self.get_plugin('LabHub').REPOS
 
     @re_botcmd(pattern=r'mergable\s+([^/]+)',  # Ignore PyCodeStyleBear
                re_cmd_name_help='pr list <repo>',

--- a/tests/corobo_test_case.py
+++ b/tests/corobo_test_case.py
@@ -32,11 +32,12 @@ class CoroboTestCase(FullStackTest):
         """Load plugin manually"""
         klass = self.klasses[plugin_name]
         plugin = klass(self.bot, plugin_name)
-        plugin.activate()
         self.plugins[plugin_name] = plugin
         self.bot.plugin_manager.plugins[plugin_name] = plugin
         plug_file = self.plug_files[plugin_name]
+        plugin.dependencies = plug_file.dependencies
         self.bot.plugin_manager.plugin_infos[plug_file.name] = plug_file
+        plugin.activate()
 
         if mock_dict:
             self.inject_mocks(plugin_name=plugin_name, mock_dict=mock_dict)

--- a/tests/git_stats_test.py
+++ b/tests/git_stats_test.py
@@ -18,17 +18,19 @@ from tests.corobo_test_case import CoroboTestCase
 class TestGitStats(CoroboTestCase):
 
     def setUp(self):
-        super().setUp((plugins.git_stats.GitStats,))
-        plugins.git_stats.github3 = create_autospec(github3)
+        super().setUp((plugins.git_stats.GitStats,
+                       plugins.labhub.LabHub,))
+        plugins.labhub.github3 = create_autospec(github3)
         self.mock_org = create_autospec(github3.orgs.Organization)
         self.mock_gh = create_autospec(github3.GitHub)
         self.mock_repo = create_autospec(IGitt.GitHub.GitHub.GitHubRepository)
-        plugins.git_stats.github3.login.return_value = self.mock_gh
+        plugins.labhub.github3.login.return_value = self.mock_gh
         self.mock_gh.organization.return_value = self.mock_org
-        plugins.git_stats.github3.organization.return_value = self.mock_org
+        plugins.labhub.github3.organization.return_value = self.mock_org
 
         self.plugin = plugins.git_stats.GitStats
         self.plugin.__bases__ = (BotPlugin, )
+        self.labhub = self.load_plugin('LabHub')
         self.git_stats = self.load_plugin('GitStats')
         self.git_stats.REPOS = {'test': self.mock_repo}
 


### PR DESCRIPTION
Inheritence was resulting in labhub commands
being triggered twice when used. This creates
dependency on labhub instead of inheritance.

Fixes https://github.com/coala/corobo/issues/441