### PR TITLE
plugins/coatils.py: Remove __init__ constructor

### DIFF
--- a/plugins/coatils.py
+++ b/plugins/coatils.py
@@ -15,9 +15,6 @@ class Coatils(BotPlugin):
     Various coala related utilities, exposing the REST API, etc.
     """
 
-    def __init__(self, bot, name=None):
-        super().__init__(bot, name)
-
     @staticmethod
     def total_bears():
         bears = client.list.bears.get().json()


### PR DESCRIPTION
This removes __init__ initializer as the __init__ in this module
only invokes super, which happens anyway if ___init__ is removed

Closes https://github.com/coala/corobo/issues/601

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
