### PR TITLE
nevermind.py: Change regex pattern

### DIFF
--- a/plugins/nevermind.py
+++ b/plugins/nevermind.py
@@ -8,7 +8,7 @@ class Nevermind(BotPlugin):
     Doesn't mind
     """
 
-    @re_botcmd(pattern=r'(nm)|(nevermind)', flags=re.IGNORECASE)
+    @re_botcmd(pattern=r'^(nm)$|^(nevermind)$', flags=re.IGNORECASE)
     def nevermind(self, message, match):
         """Doesn't mind"""
         return "I'm sorry :("

--- a/tests/nevermind_test.py
+++ b/tests/nevermind_test.py
@@ -8,3 +8,8 @@ def test_nevermind(testbot):
     testbot.assertCommand("!nm", "I'm sorry :(")
     testbot.assertCommand("!nEverMINd", "I'm sorry :(")
     testbot.assertCommand("!nM", "I'm sorry :(")
+    testbot.assertCommand("!nmxyz", 'Command "nmxyz" not found.')
+    testbot.assertCommand("!hey nM", 'Command "hey" / "hey nM" not found.')
+    testbot.assertCommand("!nevermindxyz", 'Command "nevermindxyz" not found.')
+    testbot.assertCommand(
+        "!hey nEverMINd", 'Command "hey" / "hey nEverMINd" not found.')


### PR DESCRIPTION
Change regex pattern so that corobo only apologizes
when "corobo nm" or "corobo nevermind" are used.
Also add unit tests for the same

Fixes https://github.com/coala/corobo/issues/519
# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
