### PR TITLE
LabHubTestCase: LabHub testing setup 

### DIFF
--- a/tests/git_stats_test.py
+++ b/tests/git_stats_test.py
@@ -1,5 +1,4 @@
 from tempfile import mkdtemp
-from errbot import BotPlugin
 from unittest.mock import create_autospec
 
 from IGitt.GitHub.GitHubMergeRequest import GitHubMergeRequest
@@ -8,28 +7,14 @@ from IGitt.GitHub.GitHubIssue import GitHubIssue
 from IGitt.GitLab.GitLabIssue import GitLabIssue
 from git import Repo
 
-import github3
-import IGitt
 import plugins.git_stats
-import plugins.labhub
-from tests.corobo_test_case import CoroboTestCase
+from tests.labhub_test_case import LabHubTestCase
 
 
-class TestGitStats(CoroboTestCase):
+class TestGitStats(LabHubTestCase):
 
     def setUp(self):
-        super().setUp((plugins.git_stats.GitStats,
-                       plugins.labhub.LabHub,))
-        plugins.labhub.github3 = create_autospec(github3)
-        self.mock_org = create_autospec(github3.orgs.Organization)
-        self.mock_gh = create_autospec(github3.GitHub)
-        self.mock_repo = create_autospec(IGitt.GitHub.GitHub.GitHubRepository)
-        plugins.labhub.github3.login.return_value = self.mock_gh
-        self.mock_gh.organization.return_value = self.mock_org
-        plugins.labhub.github3.organization.return_value = self.mock_org
-
-        self.plugin = plugins.git_stats.GitStats
-        self.plugin.__bases__ = (BotPlugin, )
+        super().setUp((plugins.git_stats.GitStats, plugins.labhub.LabHub,))
         self.labhub = self.load_plugin('LabHub')
         self.git_stats = self.load_plugin('GitStats')
         self.git_stats.REPOS = {'test': self.mock_repo}

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -8,45 +8,18 @@ from IGitt.GitHub.GitHubMergeRequest import GitHubMergeRequest
 from IGitt.GitLab.GitLabMergeRequest import GitLabMergeRequest
 from IGitt.GitHub.GitHubIssue import GitHubIssue
 
-from errbot.backends.test import TestBot
 from errbot.backends.base import Message
 
 import plugins.labhub
 from plugins.labhub import LabHub
 
-from tests.corobo_test_case import CoroboTestCase
+from tests.labhub_test_case import LabHubTestCase
 
 
-class TestLabHub(CoroboTestCase):
+class TestLabHub(LabHubTestCase):
 
     def setUp(self):
         super().setUp((plugins.labhub.LabHub,))
-        plugins.labhub.github3 = create_autospec(github3)
-
-        self.mock_org = create_autospec(github3.orgs.Organization)
-        self.mock_gh = create_autospec(github3.GitHub)
-        self.mock_team = create_autospec(github3.orgs.Team)
-        self.mock_team.name = PropertyMock()
-        self.mock_team.name = 'mocked team'
-        self.teams = {
-            'coala newcomers': self.mock_team,
-            'coala developers': self.mock_team,
-            'coala maintainers': self.mock_team,
-        }
-        self.mock_repo = create_autospec(IGitt.GitHub.GitHub.GitHubRepository)
-
-        plugins.labhub.github3.login.return_value = self.mock_gh
-        self.mock_gh.organization.return_value = self.mock_org
-        self.mock_org.teams.return_value = [self.mock_team]
-        plugins.labhub.github3.organization.return_value = self.mock_org
-
-        # patching
-        plugins.labhub.GitHub = create_autospec(IGitt.GitHub.GitHub.GitHub)
-        plugins.labhub.GitLab = create_autospec(IGitt.GitLab.GitLab.GitLab)
-        plugins.labhub.GitHubToken = create_autospec(IGitt.GitHub.GitHubToken)
-        plugins.labhub.GitLabPrivateToken = create_autospec(
-            IGitt.GitLab.GitLabPrivateToken)
-
         self.global_mocks = {
             'REPOS': {
                 'repository': self.mock_repo,

--- a/tests/labhub_test_case.py
+++ b/tests/labhub_test_case.py
@@ -1,0 +1,40 @@
+import github3
+import IGitt
+import plugins.labhub
+
+from unittest.mock import create_autospec, PropertyMock
+from tests.corobo_test_case import CoroboTestCase
+
+
+class LabHubTestCase(CoroboTestCase):
+
+    def setUp(self, klasses=None):
+        plugins.labhub.github3 = create_autospec(github3)
+
+        self.mock_org = create_autospec(github3.orgs.Organization)
+        self.mock_gh = create_autospec(github3.GitHub)
+        self.mock_team = create_autospec(github3.orgs.Team)
+        self.mock_team.name = PropertyMock()
+        self.mock_team.name = 'mocked team'
+        self.teams = {
+            'coala newcomers': self.mock_team,
+            'coala developers': self.mock_team,
+            'coala maintainers': self.mock_team,
+        }
+
+        self.mock_repo = create_autospec(IGitt.GitHub.GitHub.GitHubRepository)
+
+        plugins.labhub.github3.login.return_value = self.mock_gh
+        self.mock_gh.organization.return_value = self.mock_org
+        self.mock_org.teams.return_value = [self.mock_team]
+        plugins.labhub.github3.organization.return_value = self.mock_org
+
+        # patching
+        plugins.labhub.GitHub = create_autospec(IGitt.GitHub.GitHub.GitHub)
+        plugins.labhub.GitLab = create_autospec(IGitt.GitLab.GitLab.GitLab)
+        plugins.labhub.GitHubToken = create_autospec(IGitt.GitHub.GitHubToken)
+        plugins.labhub.GitLabPrivateToken = create_autospec(
+            IGitt.GitLab.GitLabPrivateToken)
+
+        if klasses:
+            super().setUp(klasses)


### PR DESCRIPTION
The role of LabHubTestCase is to do the setUp
necessary for testing a plugin which depends
on LabHub plugin. It adapts the tests for
GitStats plugins to use the LabHubTestCase.

Closes https://github.com/coala/corobo/issues/607