### PR TITLE
README.md: Update BOT_ADMINS description

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Read more about what `corobo` could do for you
 
 1. `BOT_ROOT` - absolute path of the project root.
 2. `BOT_PREFIX` - prefix to use for issuing bot commands.
-3. `BOT_ADMINS` - Admins of the errbot instance.
+3. `BOT_ADMINS` - Space separated list of admins of the errbot instance.
 4. `ROOMS` - Space separated list of rooms to join on startup. e.g.
    `ROOMS="coala/coala coala/coala/corobo"`
 5. `BACKEND` - Backend to use.


### PR DESCRIPTION
This adds an explanation that BOT_ADMINS is a space separated list.

Fixes https://github.com/coala/corobo/issues/367

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
