### PR TITLE
searchdocs_test: change http links to https

### DIFF
--- a/plugins/constants.py
+++ b/plugins/constants.py
@@ -1,6 +1,6 @@
 
-API_DOCS = 'http://api.coala.io/en/latest'
-USER_DOCS = 'http://docs.coala.io/en/latest'
+API_DOCS = 'https://api.coala.io/en/latest'
+USER_DOCS = 'https://docs.coala.io/en/latest'
 
 MAX_MSG_LEN = 1000
 MAX_LINES = 20

--- a/tests/searchdocs_test.py
+++ b/tests/searchdocs_test.py
@@ -6,9 +6,9 @@ class SearchDocsTest(IsolatedTestCase):
     def test_search_cmd(self):
         self.assertCommand(
             '!search api search string',
-            'http://api.coala.io/en/latest/search.html?q=search+string')
+            'https://api.coala.io/en/latest/search.html?q=search+string')
         self.assertCommand(
             '!search user search string',
-            'http://docs.coala.io/en/latest/search.html?q=search+string')
+            'https://docs.coala.io/en/latest/search.html?q=search+string')
         self.assertCommand('!search not matching',
                            'Invalid syntax')


### PR DESCRIPTION
This changes http:// links in constants.py file in plugins folder 
and searchdocs_test.py file in tests folder to https:// links.

Closes [#579](https://github.com/coala/corobo/issues/579)

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
