### PR TITLE
backends.py: Add profile_link function

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -206,7 +206,7 @@ class LabHub(DefaultConfigMixin, BotPlugin):
         iss_title = match.group(2)
         iss_description = match.group(3) if match.group(3) is not None else ''
         extra_msg = '\nOpened by @{username} at [{backend}]({msg_link})'.format(
-            username=user,
+            username=self.profile_link(msg),
             backend=self.bot_config.BACKEND,
             msg_link=message_link(self, msg)
         )
@@ -221,6 +221,17 @@ class LabHub(DefaultConfigMixin, BotPlugin):
             ).render(
                 target=user,
             )
+
+    @staticmethod
+    def profile_link(msg):
+        gitter_username = msg.frm.nick
+        if '_gitlab' in gitter_username:
+            pattern = '^(.*)(_.*?)$'
+            username = re.match(
+                pattern, gitter_username.split('@')[-1]).group(1)
+        else:
+            username = gitter_username.split('@')[-1]
+        return 'https://github.com/{user}'.format(user=username)
 
     @staticmethod
     def is_newcomer_issue(iss):

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -162,7 +162,7 @@ class TestLabHub(LabHubTestCase):
                 textwrap.dedent('''\
                     first line of body
                     second line of body
-                    Opened by @batman at [text]()''')
+                    Opened by @https://github.com/batman at [text]()''')
         )
 
         testbot_public.assertCommand(
@@ -177,7 +177,7 @@ class TestLabHub(LabHubTestCase):
                 'another title',
                 textwrap.dedent('''\
                     body
-                    Opened by @batman at [text]()''')
+                    Opened by @https://github.com/batman at [text]()''')
         )
 
         testbot_public.assertCommand(
@@ -206,6 +206,16 @@ class TestLabHub(LabHubTestCase):
         self.assertTrue(LabHub.is_newcomer_issue(mock_iss))
         mock_iss.labels = ('difficulty/medium',)
         self.assertFalse(LabHub.is_newcomer_issue(mock_iss))
+
+    def test_profile_link(self):
+        msg = create_autospec(Message)
+        msg.frm.nick = PropertyMock()
+        msg.frm.nick = ('@sladyn98')
+        self.assertEqual(LabHub.profile_link(msg),
+                         'https://github.com/sladyn98')
+        msg.frm.nick = ('@sladyn98_gitlab')
+        self.assertEqual(LabHub.profile_link(msg),
+                         'https://gitlab.com/sladyn98')
 
     def test_unassign_cmd(self):
         self.inject_mocks('LabHub', {'REPOS': {'example': self.mock_repo}})


### PR DESCRIPTION
This function is created to map github and gitlab usernames.
Ensures correct profile links are mapped for both websites.

Fixes https://github.com/coala/corobo/issues/347

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
