### PR TITLE
config.py: Remove corobo as default prefix

### DIFF
--- a/config.py
+++ b/config.py
@@ -64,7 +64,10 @@ BOT_EXTRA_PLUGIN_DIR = BOT_ROOT
 BOT_LOG_FILE = os.path.join(BOT_ROOT, 'errbot.log')
 BOT_LOG_LEVEL = logging.DEBUG
 
-BOT_PREFIX = os.environ.get('BOT_PREFIX', 'corobo ')
+if not os.environ.get('BOT_PREFIX'):
+    raise SystemExit("Environment variable BOT_PREFIX not specified")
+
+BOT_PREFIX = os.environ.get('BOT_PREFIX')
 
 if 'COBOT_PREFIX' in os.environ:
     BOT_PREFIX = os.environ['COBOT_PREFIX']


### PR DESCRIPTION
Removed `corobo` as default `BOT_PREFIX`
and added a check for empty `BOT_PREFIX`

Closes https://github.com/coala/corobo/issues/365

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
