### PR TITLE
labhub.py: Add duplicate issue title check

### DIFF
--- a/plugins/labhub.py
+++ b/plugins/labhub.py
@@ -213,6 +213,14 @@ class LabHub(DefaultConfigMixin, BotPlugin):
 
         if repo_name in self.REPOS:
             repo = self.REPOS[repo_name]
+            query = iss_title + " is:issue " + "coala in:name"
+            issue_list = list(GitHub.raw_search(
+                GitHubToken(self.config['GH_TOKEN'], query)))
+            for issue in issue_list:
+                if iss_title.lower() == issue.title.lower():
+                    yield 'An issue with same title already exists at {}'.format(
+                        issue.web_url)
+                    return
             iss = repo.create_issue(iss_title, iss_description + extra_msg)
             yield 'Here you go: {}'.format(iss.web_url)
         else:

--- a/tests/labhub_test.py
+++ b/tests/labhub_test.py
@@ -199,6 +199,14 @@ class TestLabHub(LabHubTestCase):
             'You need to be a member of this organization to use this command.'
         )
 
+        # issue title already exists
+        mock_iss = create_autospec(IGitt.GitHub.GitHubIssue)
+        mock_iss.title = PropertyMock()
+        mock_iss.title = ('title',)
+        testbot_public.assertCommand(
+            '!!new issue coala title',
+            'An issue with same title already exists')
+
     def test_is_newcomer_issue(self):
         mock_iss = create_autospec(IGitt.GitHub.GitHubIssue)
         mock_iss.labels = PropertyMock()


### PR DESCRIPTION
Added a duplicate issue check to warn
the user of a duplicate issue title.

Closes https://github.com/coala/corobo/issues/291

# Reviewers Checklist

- [ ] Appropriate logging is done.
- [ ] Appropriate error responses.
- [ ] Handle every possible exception.
- [ ] Make sure there is a docstring in the command functions. Hint: Lookout for
  `botcmd` and `re_botcmd` decorators.
- [ ] See that 100% coverage is there.
- [ ] See to it that mocking is not done where it is not necessary.
